### PR TITLE
Expand external new tab helper to additional sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Hide/click/scrollTo elements on specific sites for better reading experience:
 - [PanSci](https://pansci.asia/)
 - [INSIDE](https://www.inside.com.tw/)
 
+## [Articles External New Tab User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ArticlesExternalNewTab.user.js)
+
+Ensure external story links on [Hacker News](https://news.ycombinator.com/), [hackernews.betacat.io](https://hackernews.betacat.io/), [The Neuron Daily](https://www.theneurondaily.com/), and [Taipei City Government news galleries](https://tam.gov.taipei/) open in background tabs and display a ↗︎ icon indicator.
+
 ## Installation
 
 ### Prerequisites:
@@ -64,6 +68,7 @@ Hide/click/scrollTo elements on specific sites for better reading experience:
   - [ArXiv.user.js](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ArXiv.user.js)
   - [TheNeuronDaily.user.js](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/TheNeuronDaily.user.js)
   - [HideBanner.user.js](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/HideBanner.user.js)
+  - [ArticlesExternalNewTab.user.js](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ArticlesExternalNewTab.user.js)
 
 2. Tampermonkey Install page opened, click [Install] button to install.
 3. Reload the target page.

--- a/TestCases.md
+++ b/TestCases.md
@@ -1,23 +1,24 @@
 # Archive Today
-https://www.404media.co/anyone-can-push-updates-to-the-doge-gov-website-2/
-https://www.economist.com/interactive/christmas-specials/2024/12/21/the-chart-of-everything
-https://www.ft.com/content/a3eeb268-5daa-4525-858b-eab93b28d3c7
-https://www.nature.com/articles/d41586-025-00648-5
-https://www.newscientist.com/article/2458385-ai-uses-throat-vibrations-to-work-out-what-someone-is-trying-to-say/
-https://www.newyorker.com/magazine/2025/02/17/the-long-flight-to-teach-an-endangered-ibis-species-to-migrate
-https://www.nytimes.com/2024/12/23/health/mpox-spread-congo-kinshasa.html
-https://www.theatlantic.com/magazine/archive/2025/02/american-loneliness-personality-politics/681091/
-https://www.theatlantic.com/health/archive/2015/07/split-brain-research-sperry-gazzaniga/399290/https://www.wired.com/story/elon-musk-government-young-engineers/
-https://www.wsj.com/world/dozens-feared-dead-in-crash-after-passenger-flight-diverts-from-russia-fb2cdf2c
+- https://www.404media.co/anyone-can-push-updates-to-the-doge-gov-website-2/
+- https://www.economist.com/interactive/christmas-specials/2024/12/21/the-chart-of-everything
+- https://www.ft.com/content/a3eeb268-5daa-4525-858b-eab93b28d3c7
+- https://www.nature.com/articles/d41586-025-00648-5
+- https://www.newscientist.com/article/2458385-ai-uses-throat-vibrations-to-work-out-what-someone-is-trying-to-say/
+- https://www.newyorker.com/magazine/2025/02/17/the-long-flight-to-teach-an-endangered-ibis-species-to-migrate
+- https://www.nytimes.com/2024/12/23/health/mpox-spread-congo-kinshasa.html
+- https://www.theatlantic.com/magazine/archive/2025/02/american-loneliness-personality-politics/681091/
+- https://www.theatlantic.com/health/archive/2015/07/split-brain-research-sperry-gazzaniga/399290/
+- https://www.wired.com/story/elon-musk-government-young-engineers/
+- https://www.wsj.com/world/dozens-feared-dead-in-crash-after-passenger-flight-diverts-from-russia-fb2cdf2c
 
 # Internet Archive
-https://www.lrb.co.uk/the-paper/v47/n01/fraser-macdonald/diary
-https://www.rawstory.com/laura-loomer-vs-elon-musk/
-https://www.smh.com.au/business/the-economy/trump-is-changing-the-narratives-on-both-sides-of-the-atlantic-20250310-p5liav.html
-https://www.theverge.com/2025/1/15/24343794/google-workspace-ai-features-free
+- https://www.lrb.co.uk/the-paper/v47/n01/fraser-macdonald/diary
+- https://www.rawstory.com/laura-loomer-vs-elon-musk/
+- https://www.smh.com.au/business/the-economy/trump-is-changing-the-narratives-on-both-sides-of-the-atlantic-20250310-p5liav.html
+- https://www.theverge.com/2025/1/15/24343794/google-workspace-ai-features-free
 
 # Previous Internet Archive, now Archive Today, waiting for next sample
-https://www.newyorker.com/news/the-lede/geothermal-power-is-a-climate-moon-shot-beneath-our-feet
+- https://www.newyorker.com/news/the-lede/geothermal-power-is-a-climate-moon-shot-beneath-our-feet
 
 # None
-https://www.nature.com/articles/d41586-025-00264-3
+- https://www.nature.com/articles/d41586-025-00264-3

--- a/src/ArticlesExternalNewTab.user.js
+++ b/src/ArticlesExternalNewTab.user.js
@@ -1,0 +1,193 @@
+// ==UserScript==
+// @name         Articles External Links New Tab
+// @namespace    http://tampermonkey.net/
+// @version      2025-10-07_2.0.0
+// @description  Keep article links on supported news hubs opening in background tabs with a ↗︎ indicator.
+// @author       ChrisTorng
+// @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
+// @downloadURL  https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ArticlesExternalNewTab.user.js
+// @updateURL    https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ArticlesExternalNewTab.user.js
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=news.ycombinator.com
+// @match        https://news.ycombinator.com/*
+// @match        https://hackernews.betacat.io/*
+// @match        https://www.theneurondaily.com/*
+// @match        https://tam.gov.taipei/News_Photo.aspx*
+// @match        https://tam.gov.taipei/News_Link_pic.aspx*
+// @grant        GM_openInTab
+// ==/UserScript==
+
+(function () {
+    'use strict';
+
+    const INTERNAL_HOSTS = new Set([
+        'news.ycombinator.com',
+        'hackernews.betacat.io',
+        'www.theneurondaily.com',
+        'tam.gov.taipei',
+    ]);
+    const STYLE_ID = 'tampermonkey-articles-new-tab-style';
+    const ICON_CLASS_NAME = 'articles-new-tab-icon';
+    const PROCESSED_FLAG = 'articlesNewTabProcessed';
+    const LISTENER_FLAG = 'articlesNewTabListenerAttached';
+    const ICON_TEXT = '↗︎';
+
+    function ensureStyles() {
+        if (document.getElementById(STYLE_ID)) {
+            return;
+        }
+
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = `
+            .${ICON_CLASS_NAME} {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                margin-left: 0.35em;
+                font-size: 0.8em;
+                line-height: 1;
+                text-decoration: none;
+                color: inherit;
+            }
+        `;
+        document.head.appendChild(style);
+    }
+
+    function createIconElement() {
+        const span = document.createElement('span');
+        span.className = ICON_CLASS_NAME;
+        span.setAttribute('aria-hidden', 'true');
+        span.textContent = ICON_TEXT;
+        return span;
+    }
+
+    function markAsProcessed(link) {
+        link.dataset[PROCESSED_FLAG] = 'true';
+    }
+
+    function hasBeenProcessed(link) {
+        return link.dataset[PROCESSED_FLAG] === 'true';
+    }
+
+    function isExternalLink(link) {
+        if (!link || !link.href) {
+            return false;
+        }
+
+        try {
+            const url = new URL(link.href, window.location.href);
+            return !INTERNAL_HOSTS.has(url.hostname);
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function ensureTargetAttributes(link) {
+        link.target = '_blank';
+
+        if (link.relList && typeof link.relList.add === 'function') {
+            link.relList.add('noopener', 'noreferrer');
+        } else {
+            link.rel = 'noopener noreferrer';
+        }
+    }
+
+    function openInBackgroundTab(url) {
+        if (typeof GM_openInTab === 'function') {
+            GM_openInTab(url, { active: false, insert: true });
+            return;
+        }
+
+        window.open(url, '_blank', 'noopener');
+    }
+
+    function attachClickListener(link) {
+        if (link.dataset[LISTENER_FLAG] === 'true') {
+            return;
+        }
+
+        link.addEventListener('click', (event) => {
+            if (event.defaultPrevented) {
+                return;
+            }
+
+            if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                return;
+            }
+
+            event.preventDefault();
+            openInBackgroundTab(link.href);
+        });
+
+        link.dataset[LISTENER_FLAG] = 'true';
+    }
+
+    function appendIcon(link) {
+        if (!link.parentElement) {
+            return;
+        }
+
+        const icon = createIconElement();
+        link.insertAdjacentElement('afterend', icon);
+    }
+
+    function processLink(link) {
+        if (hasBeenProcessed(link) || !isExternalLink(link)) {
+            return;
+        }
+
+        ensureTargetAttributes(link);
+        attachClickListener(link);
+        appendIcon(link);
+        markAsProcessed(link);
+    }
+
+    function processAllLinks(root) {
+        const isSupportedRoot =
+            root === document ||
+            root instanceof Element ||
+            root instanceof DocumentFragment;
+
+        if (!isSupportedRoot) {
+            return;
+        }
+
+        const links = root.querySelectorAll ? root.querySelectorAll('a[href]') : [];
+        links.forEach(processLink);
+    }
+
+    function observeMutations() {
+        const observer = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                mutation.addedNodes.forEach((node) => {
+                    if (node instanceof Element) {
+                        if (node.matches('a[href]')) {
+                            processLink(node);
+                        }
+
+                        processAllLinks(node);
+                        return;
+                    }
+
+                    if (node instanceof DocumentFragment) {
+                        processAllLinks(node);
+                    }
+                });
+            }
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    function init() {
+        ensureStyles();
+        processAllLinks(document);
+        observeMutations();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init, { once: true });
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## Summary
- rename the external new-tab userscript to ArticlesExternalNewTab and extend coverage to TheNeuronDaily and tam.gov.taipei galleries
- keep background tab behavior and icon injection working for dynamic content across all supported domains
- document the renamed script and improve the Markdown list formatting in TestCases.md

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e41a320a388322a04ba2f35d096cd7