### PR TITLE
feat: AutoOpenNewArticles 新增 The Neuron Daily 支援

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Open external links in background tabs with a ↗︎ indicator on:
 
 ## [Auto Open New Articles User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/AutoOpenNewArticles.user.js)
 
-Track the latest seen article and open newly listed Taipei Astronomical Museum news items in background tabs with a yellow star.
+Track the latest seen article and auto-open newly listed items in background tabs with a yellow star on Taipei Astronomical Museum and The Neuron Daily.
 
 ## [Coding Diff Optimizer User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/CodingOptimizer.user.js)
 

--- a/TestCases.md
+++ b/TestCases.md
@@ -57,8 +57,10 @@ Section note: automated tests inject the script and mock `GM_openInTab`.
 
 # AutoOpenNewArticles
 Section note: automated tests inject the script and mock `GM_getValue`, `GM_setValue`, and `GM_openInTab`.
-- https://tam.gov.taipei/News_Photo.aspx?n=EF86D8AF23B9A85B [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
-- https://tam.gov.taipei/News_Link_pic.aspx?n=B64052C7930D4913 [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
+- https://tam.gov.taipei/News_Photo.aspx?n=EF86D8AF23B9A85B [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
+- https://tam.gov.taipei/News_Link_pic.aspx?n=B64052C7930D4913 [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
+- https://www.theneurondaily.com/ [CONTENT_CLASS: INVALID_ANTI_BOT] [TEST_STATUS: AUTOMATED] (listing detection and new-item open flow validated with local DOM harness)
+- https://www.theneurondaily.com/archive [CONTENT_CLASS: INVALID_ANTI_BOT] [TEST_STATUS: AUTOMATED] (listing detection and new-item open flow validated with local DOM harness)
 
 # Coding Diff Optimizer
 - https://chatgpt.com/codex/tasks/task_e_68e41a320a388322a04ba2f35d096cd7 [CONTENT_CLASS: INVALID_ANTI_BOT] [TEST_STATUS: LIMITED] (anti-bot sample; synthetic diff selector on supported Codex URL)

--- a/scripts/test-auto-open-new-articles.js
+++ b/scripts/test-auto-open-new-articles.js
@@ -157,9 +157,13 @@ describe('AutoOpenNewArticles on The Neuron Daily listings', () => {
         const section = harness.document.createElement('section');
         harness.appendToBody(section);
 
-        const newLink = createLink(harness.document, 'https://www.theneurondaily.com/p/new-agent-release', {
-            textContent: 'New Agent Release'
-        });
+        const newLink = createLink(harness.document, 'https://www.theneurondaily.com/p/new-agent-release');
+        const hiddenMetaSpan = harness.document.createElement('span');
+        hiddenMetaSpan.textContent = 'Hidden Meta';
+        const titleHeading = harness.document.createElement('h3');
+        titleHeading.textContent = 'New Agent Release';
+        newLink.append(hiddenMetaSpan, titleHeading);
+
         const seenLink = createLink(harness.document, 'https://www.theneurondaily.com/p/older-ai-news', {
             textContent: 'Older AI News'
         });
@@ -177,5 +181,6 @@ describe('AutoOpenNewArticles on The Neuron Daily listings', () => {
         assert.equal(openCalls[0].options.insert, true);
         assert.equal(gmStore.get(storageKey), 'theneurondaily:/p/new-agent-release');
         assert.equal(newLink.firstChild.textContent, '★');
+        assert.equal(hiddenMetaSpan.firstChild, null);
     });
 });

--- a/scripts/test-auto-open-new-articles.js
+++ b/scripts/test-auto-open-new-articles.js
@@ -123,3 +123,59 @@ describe('AutoOpenNewArticles on captured Taipei museum listings', () => {
         });
     }
 });
+
+describe('AutoOpenNewArticles on The Neuron Daily listings', () => {
+    test('stores the latest article on first visit and does not open tabs', () => {
+        const openCalls = [];
+        const { harness, gmStore } = createAutoOpenHarness('https://www.theneurondaily.com/', {}, openCalls);
+        const main = harness.document.createElement('main');
+        harness.appendToBody(main);
+
+        const firstLink = createLink(harness.document, 'https://www.theneurondaily.com/p/latest-ai-breakthrough', {
+            textContent: 'Latest AI Breakthrough'
+        });
+        const secondLink = createLink(harness.document, 'https://www.theneurondaily.com/p/older-ai-news', {
+            textContent: 'Older AI News'
+        });
+        main.append(firstLink, secondLink);
+
+        runAutoOpenScript(harness);
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        assert.equal(openCalls.length, 0);
+        assert.equal(gmStore.get('autoOpenNewArticles:lastSeen:theneurondaily:listings'), 'theneurondaily:/p/latest-ai-breakthrough');
+    });
+
+    test('opens unseen Neuron Daily articles in background and marks the newest one', () => {
+        const openCalls = [];
+        const storageKey = 'autoOpenNewArticles:lastSeen:theneurondaily:listings';
+        const { harness, gmStore } = createAutoOpenHarness(
+            'https://www.theneurondaily.com/archive',
+            { [storageKey]: 'theneurondaily:/p/older-ai-news' },
+            openCalls
+        );
+        const section = harness.document.createElement('section');
+        harness.appendToBody(section);
+
+        const newLink = createLink(harness.document, 'https://www.theneurondaily.com/p/new-agent-release', {
+            textContent: 'New Agent Release'
+        });
+        const seenLink = createLink(harness.document, 'https://www.theneurondaily.com/p/older-ai-news', {
+            textContent: 'Older AI News'
+        });
+        const duplicateNewLink = createLink(harness.document, 'https://www.theneurondaily.com/p/new-agent-release', {
+            textContent: 'Duplicate New Agent Release'
+        });
+
+        section.append(newLink, seenLink, duplicateNewLink);
+        runAutoOpenScript(harness);
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        assert.equal(openCalls.length, 1);
+        assert.equal(openCalls[0].href, 'https://www.theneurondaily.com/p/new-agent-release');
+        assert.equal(openCalls[0].options.active, false);
+        assert.equal(openCalls[0].options.insert, true);
+        assert.equal(gmStore.get(storageKey), 'theneurondaily:/p/new-agent-release');
+        assert.equal(newLink.firstChild.textContent, '★');
+    });
+});

--- a/src/AutoOpenNewArticles.user.js
+++ b/src/AutoOpenNewArticles.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Auto Open New Articles
 // @namespace    http://tampermonkey.net/
-// @version      2026-03-16_1.1.0
+// @version      2026-03-18_1.1.1
 // @description  Track the latest seen article and open newly listed articles on Taipei Astronomical Museum and The Neuron Daily in background tabs with a yellow star.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -121,6 +121,10 @@
     }
 
     function getTitleElement(link) {
+        if (window.location.hostname === 'www.theneurondaily.com') {
+            return link;
+        }
+
         if (link.classList.contains('caption')) {
             return link;
         }

--- a/src/AutoOpenNewArticles.user.js
+++ b/src/AutoOpenNewArticles.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Auto Open New Articles
 // @namespace    http://tampermonkey.net/
-// @version      2026-01-27_1.0.0
-// @description  Track the latest seen article and open newly listed Taipei Astronomical Museum news items in background tabs with a yellow star.
+// @version      2026-03-16_1.1.0
+// @description  Track the latest seen article and open newly listed articles on Taipei Astronomical Museum and The Neuron Daily in background tabs with a yellow star.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
 // @downloadURL  https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/AutoOpenNewArticles.user.js
@@ -10,6 +10,8 @@
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=tam.gov.taipei
 // @match        https://tam.gov.taipei/News_Photo.aspx*
 // @match        https://tam.gov.taipei/News_Link_pic.aspx*
+// @match        https://www.theneurondaily.com/
+// @match        https://www.theneurondaily.com/archive*
 // @grant        GM_getValue
 // @grant        GM_setValue
 // @grant        GM_openInTab
@@ -40,23 +42,82 @@
         document.head.appendChild(style);
     }
 
-    function getStorageKey() {
+    function getSiteConfig() {
         const url = new URL(window.location.href);
-        const listId = url.searchParams.get('n') || 'unknown';
-        return `${STORAGE_PREFIX}:${url.pathname}:${listId}`;
-    }
 
-    function getArticleId(link, listId) {
-        try {
-            const url = new URL(link.href, window.location.href);
-            const contentId = url.searchParams.get('s');
-            if (contentId) {
-                return `${listId}:${contentId}`;
+        if (url.hostname === 'tam.gov.taipei') {
+            const listId = url.searchParams.get('n');
+            if (!listId) {
+                return null;
             }
-            return `${listId}:${url.pathname}${url.search}`;
-        } catch (error) {
-            return `${listId}:${link.href}`;
+
+            return {
+                scope: `${url.pathname}:${listId}`,
+                collectArticleLinks: () => {
+                    const contentRoot = document.querySelector('#CCMS_Content') || document.body;
+                    const candidates = Array.from(contentRoot.querySelectorAll('a[href*="News_Content.aspx"]'));
+
+                    return candidates.filter((link) => link.href.includes(`n=${listId}`));
+                },
+                getArticleId: (link) => {
+                    try {
+                        const articleUrl = new URL(link.href, window.location.href);
+                        const contentId = articleUrl.searchParams.get('s');
+                        if (contentId) {
+                            return `${listId}:${contentId}`;
+                        }
+                        return `${listId}:${articleUrl.pathname}${articleUrl.search}`;
+                    } catch (error) {
+                        return `${listId}:${link.href}`;
+                    }
+                }
+            };
         }
+
+        if (url.hostname === 'www.theneurondaily.com') {
+            const isListingPage = url.pathname === '/' || url.pathname === '/archive';
+            if (!isListingPage) {
+                return null;
+            }
+
+            return {
+                scope: 'theneurondaily:listings',
+                collectArticleLinks: () => {
+                    const candidates = Array.from(document.querySelectorAll('a[href]'));
+                    const seen = new Set();
+
+                    return candidates.filter((link) => {
+                        try {
+                            const articleUrl = new URL(link.href, window.location.href);
+                            const isArticle = articleUrl.origin === url.origin && articleUrl.pathname.startsWith('/p/');
+                            if (!isArticle) {
+                                return false;
+                            }
+
+                            const key = articleUrl.pathname;
+                            if (seen.has(key)) {
+                                return false;
+                            }
+
+                            seen.add(key);
+                            return true;
+                        } catch (error) {
+                            return false;
+                        }
+                    });
+                },
+                getArticleId: (link) => {
+                    try {
+                        const articleUrl = new URL(link.href, window.location.href);
+                        return `theneurondaily:${articleUrl.pathname}`;
+                    } catch (error) {
+                        return `theneurondaily:${link.href}`;
+                    }
+                }
+            };
+        }
+
+        return null;
     }
 
     function getTitleElement(link) {
@@ -79,18 +140,10 @@
         titleElement.insertBefore(star, titleElement.firstChild);
     }
 
-    function collectArticleLinks(listId) {
-        const contentRoot = document.querySelector('#CCMS_Content') || document.body;
-        const candidates = Array.from(contentRoot.querySelectorAll('a[href*="News_Content.aspx"]'));
-
-        return candidates.filter((link) => link.href.includes(`n=${listId}`));
-    }
-
     function openNewArticles(articles, lastSeenId) {
         const lastSeenIndex = articles.findIndex((article) => article.id === lastSeenId);
         if (lastSeenIndex <= 0) {
             return {
-                newArticles: lastSeenIndex === 0 ? [] : [],
                 foundLastSeen: lastSeenIndex === 0,
             };
         }
@@ -102,22 +155,21 @@
         });
 
         return {
-            newArticles,
             foundLastSeen: true,
         };
     }
 
     function handleArticles() {
-        const listId = new URL(window.location.href).searchParams.get('n');
-        if (!listId) {
+        const siteConfig = getSiteConfig();
+        if (!siteConfig) {
             return;
         }
 
         ensureStyles();
 
-        const storageKey = getStorageKey();
+        const storageKey = `${STORAGE_PREFIX}:${siteConfig.scope}`;
         const lastSeenId = GM_getValue(storageKey, '');
-        const links = collectArticleLinks(listId);
+        const links = siteConfig.collectArticleLinks();
 
         if (links.length === 0) {
             return;
@@ -125,7 +177,7 @@
 
         const articles = links.map((link) => ({
             link,
-            id: getArticleId(link, listId),
+            id: siteConfig.getArticleId(link),
         }));
 
         const latestId = articles[0].id;


### PR DESCRIPTION
### Motivation
- 將 `AutoOpenNewArticles` 擴充為同時支援 Taipei Astronomical Museum 與 The Neuron Daily 的清單頁面，讓不同來源各自維護「最後看到」文章的追蹤狀態並保留自動在背景分頁開新文章與黃星標記的行為。 
- 同步更新 userscript metadata（版本與描述）與文件，以反映新支援的站點與測試覆蓋情況。

### Description
- 在 `src/AutoOpenNewArticles.user.js` 新增 site-aware 設計 `getSiteConfig()`，為 `tam.gov.taipei` 與 `www.theneurondaily.com` 提供各自的文章蒐集、去重與 ID 生成邏輯，並以 `STORAGE_PREFIX:<scope>` 區分儲存 key。 
- 將 userscript metadata 版本調整為 `2026-03-16_1.1.0`，並在檔頭加入 The Neuron Daily 的 `@match` 規則與更新的 `@description`。 
- 新增/修改測試：擴充 `scripts/test-auto-open-new-articles.js`，加入 The Neuron Daily 的首次記錄與新文章開啟兩個情境；同時更新 `README.md` 與 `TestCases.md` 的說明與測試狀態註記。 

### Testing
- 已執行局部測試 `node --test scripts/test-auto-open-new-articles.js`，該測試檔全部通過。 
- 已執行整套測試 `node --test`，整套測試通過（全部測試數目通過，無失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8805f79f48322a443c2b4d53ae9f1)