### PR TITLE
修正 ForceMobileView 放大字體導致行距重疊並加入 Steve Blank 測資

### DIFF
--- a/TestCases.md
+++ b/TestCases.md
@@ -80,7 +80,7 @@ Section note: automated tests inject the script and mock `GM_info`.
 - https://news.ycombinator.com/item?id=46255285 [CONTENT_CLASS: VALID_NON_ARTICLE_OR_LISTING] [TEST_STATUS: AUTOMATED]
 - https://archive.is/75aY9 [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
 - https://lcamtuf.coredump.cx/prep/index-old.shtml [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (tiny-font auto-enable behavior)
-- https://daringfireball.net/2026/03/your_frustration_is_the_product [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: LIMITED] (mobile spacing logic is AUTOMATED via synthetic DOM harness, but full live-page capture coverage is still limited)
+- https://daringfireball.net/2026/03/your_frustration_is_the_product [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: LIMITED] (mobile spacing logic is AUTOMATED via synthetic DOM harness, including minimal side-whitespace enforcement; full live-page capture coverage is still limited)
 - https://steveblank.com/2026/04/09/nowhere-is-safe/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (line-height overlap regression is simulated with local DOM harness against captured page content)
 
 # Better Mobile View

--- a/TestCases.md
+++ b/TestCases.md
@@ -81,6 +81,7 @@ Section note: automated tests inject the script and mock `GM_info`.
 - https://archive.is/75aY9 [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
 - https://lcamtuf.coredump.cx/prep/index-old.shtml [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (tiny-font auto-enable behavior)
 - https://daringfireball.net/2026/03/your_frustration_is_the_product [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: LIMITED] (mobile spacing logic is AUTOMATED via synthetic DOM harness, but full live-page capture coverage is still limited)
+- https://steveblank.com/2026/04/09/nowhere-is-safe/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (line-height overlap regression is simulated with local DOM harness against captured page content)
 
 # Better Mobile View
 - https://hackernews.betacat.io/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT]

--- a/TestCases.md
+++ b/TestCases.md
@@ -80,7 +80,7 @@ Section note: automated tests inject the script and mock `GM_info`.
 - https://news.ycombinator.com/item?id=46255285 [CONTENT_CLASS: VALID_NON_ARTICLE_OR_LISTING] [TEST_STATUS: AUTOMATED]
 - https://archive.is/75aY9 [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
 - https://lcamtuf.coredump.cx/prep/index-old.shtml [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (tiny-font auto-enable behavior)
-- https://daringfireball.net/2026/03/your_frustration_is_the_product [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: LIMITED] (mobile spacing logic is AUTOMATED via synthetic DOM harness, including minimal side-whitespace and desktop sidebar flattening; full live-page capture coverage is still limited)
+- https://daringfireball.net/2026/03/your_frustration_is_the_product [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: LIMITED] (mobile spacing logic is AUTOMATED via synthetic DOM harness, but full live-page capture coverage is still limited)
 - https://steveblank.com/2026/04/09/nowhere-is-safe/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (line-height overlap regression is simulated with local DOM harness against captured page content)
 
 # Better Mobile View

--- a/TestCases.md
+++ b/TestCases.md
@@ -80,7 +80,7 @@ Section note: automated tests inject the script and mock `GM_info`.
 - https://news.ycombinator.com/item?id=46255285 [CONTENT_CLASS: VALID_NON_ARTICLE_OR_LISTING] [TEST_STATUS: AUTOMATED]
 - https://archive.is/75aY9 [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
 - https://lcamtuf.coredump.cx/prep/index-old.shtml [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (tiny-font auto-enable behavior)
-- https://daringfireball.net/2026/03/your_frustration_is_the_product [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: LIMITED] (mobile spacing logic is AUTOMATED via synthetic DOM harness, including minimal side-whitespace enforcement; full live-page capture coverage is still limited)
+- https://daringfireball.net/2026/03/your_frustration_is_the_product [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: LIMITED] (mobile spacing logic is AUTOMATED via synthetic DOM harness, including minimal side-whitespace and desktop sidebar flattening; full live-page capture coverage is still limited)
 - https://steveblank.com/2026/04/09/nowhere-is-safe/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (line-height overlap regression is simulated with local DOM harness against captured page content)
 
 # Better Mobile View

--- a/scripts/test-force-mobile-view.js
+++ b/scripts/test-force-mobile-view.js
@@ -12,9 +12,11 @@ const scriptContents = fs.readFileSync(scriptPath, 'utf8');
 const hnFixturePath = path.join(repoRoot, 'tests', 'Force Mobile View', 'news.ycombinator.com_item_id_46255285.html');
 const archiveFixturePath = path.join(repoRoot, 'tests', 'Force Mobile View', 'archive.is_75aY9.html');
 const lcamtufFixturePath = path.join(repoRoot, 'tests', 'Force Mobile View', 'lcamtuf.coredump.cx_prep_index-old.shtml.html');
+const steveBlankFixturePath = path.join(repoRoot, 'tests', 'Force Mobile View', 'steveblank.com_2026_04_09_nowhere-is-safe.html');
 const hnFixtureHtml = fs.readFileSync(hnFixturePath, 'utf8');
 const archiveFixtureHtml = fs.readFileSync(archiveFixturePath, 'utf8');
 const lcamtufFixtureHtml = fs.readFileSync(lcamtufFixturePath, 'utf8');
+const steveBlankFixtureHtml = fs.readFileSync(steveBlankFixturePath, 'utf8');
 
 function executeForceMobileView(url, options = {}) {
     const harness = createHarness({
@@ -74,13 +76,15 @@ function executeForceMobileView(url, options = {}) {
 }
 
 describe('ForceMobileView on captured pages', () => {
-    test('fixtures contain captured HN, archive.is, and lcamtuf content', () => {
+    test('fixtures contain captured HN, archive.is, lcamtuf, and Steve Blank content', () => {
         assert.match(hnFixtureHtml, /CONTENT_CLASS:\s*VALID_/);
         assert.match(hnFixtureHtml, /hnmain/);
         assert.match(archiveFixtureHtml, /CONTENT_CLASS:\s*VALID_/);
         assert.match(archiveFixtureHtml, /archive\.is/i);
         assert.match(lcamtufFixtureHtml, /CONTENT_CLASS:\s*VALID_/);
         assert.match(lcamtufFixtureHtml, /lcamtuf\.coredump\.cx/i);
+        assert.match(steveBlankFixtureHtml, /CONTENT_CLASS:\s*VALID_/);
+        assert.match(steveBlankFixtureHtml, /steveblank\.com/i);
     });
 
     test('matched URL auto-enables mobile view style, min font enforcement, and toggle button', () => {
@@ -95,7 +99,7 @@ describe('ForceMobileView on captured pages', () => {
         assert(button, 'Expected mobile view toggle button to be created.');
         assert.equal(button.getAttribute('aria-pressed'), 'true');
         assert.equal(textElement.style.getPropertyValue('font-size'), '18px');
-        assert.equal(textElement.style.getPropertyValue('line-height'), '1.4');
+        assert.equal(textElement.style.getPropertyValue('line-height'), '25.2px');
         assert.equal(textElement.getAttribute('data-tm-force-width-min-font'), 'true');
     });
 
@@ -167,5 +171,60 @@ describe('ForceMobileView on captured pages', () => {
         assert.equal(post.style.getPropertyValue('margin-left'), '');
         assert.equal(post.style.getPropertyValue('padding-left'), '');
         assert.equal(post.getAttribute('data-tm-force-width-spacing-trimmed'), null);
+    });
+
+    test('legacy font-only boost overlaps text lines, while current behavior raises parent line-height', () => {
+        const { harness } = executeForceMobileView('https://steveblank.com/2026/04/09/nowhere-is-safe/', {
+            fixtureHtml: steveBlankFixtureHtml,
+            computedStyle(element) {
+                const inlineFont = element.style.getPropertyValue('font-size');
+                const inlineLineHeight = element.style.getPropertyValue('line-height');
+                if (element.id === 'problem-line-box') {
+                    return {
+                        fontSize: inlineFont || '20px',
+                        lineHeight: inlineLineHeight || '12px',
+                        marginLeft: '0px',
+                        marginRight: '0px',
+                        paddingLeft: '0px',
+                        paddingRight: '0px'
+                    };
+                }
+                if (element.id === 'problem-small-text') {
+                    return {
+                        fontSize: inlineFont || '10px',
+                        lineHeight: inlineLineHeight || '10px',
+                        marginLeft: '0px',
+                        marginRight: '0px',
+                        paddingLeft: '0px',
+                        paddingRight: '0px'
+                    };
+                }
+                return {
+                    fontSize: inlineFont || '16px',
+                    lineHeight: inlineLineHeight || '22px',
+                    marginLeft: '0px',
+                    marginRight: '0px',
+                    paddingLeft: '0px',
+                    paddingRight: '0px'
+                };
+            }
+        });
+        const paragraph = harness.document.createElement('p');
+        paragraph.id = 'problem-line-box';
+        const span = harness.document.createElement('span');
+        span.id = 'problem-small-text';
+        span.textContent = 'Dense translated text';
+        paragraph.appendChild(span);
+        harness.appendToBody(paragraph);
+
+        const legacyLineHeight = 12;
+        const legacyFontAfterBoost = 18;
+        assert(legacyLineHeight < legacyFontAfterBoost, 'Legacy font-only boost would have line overlap.');
+
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+        assert.equal(span.style.getPropertyValue('font-size'), '18px');
+        assert.equal(span.style.getPropertyValue('line-height'), '25.2px');
+        assert.equal(paragraph.getAttribute('data-tm-force-width-min-line-height-only'), 'true');
+        assert.equal(paragraph.style.getPropertyValue('line-height'), '28px');
     });
 });

--- a/scripts/test-force-mobile-view.js
+++ b/scripts/test-force-mobile-view.js
@@ -48,6 +48,10 @@ function executeForceMobileView(url, options = {}) {
             }
             return {
                 fontSize: element.tagName === 'SPAN' ? '10px' : '16px',
+                lineHeight: '22px',
+                width: '360px',
+                position: 'static',
+                float: 'none',
                 marginLeft: '0px',
                 marginRight: '0px',
                 paddingLeft: '0px',
@@ -148,6 +152,10 @@ describe('ForceMobileView on captured pages', () => {
             computedStyle(element) {
                 return {
                     fontSize: '16px',
+                    lineHeight: '22px',
+                    width: element.id === 'post' ? '320px' : '360px',
+                    position: 'static',
+                    float: 'none',
                     marginLeft: element.id === 'post' ? '24px' : '0px',
                     marginRight: element.id === 'post' ? '24px' : '0px',
                     paddingLeft: element.id === 'post' ? '18px' : '0px',
@@ -177,6 +185,75 @@ describe('ForceMobileView on captured pages', () => {
         assert.equal(post.style.getPropertyValue('margin-left'), '');
         assert.equal(post.style.getPropertyValue('padding-left'), '');
         assert.equal(post.getAttribute('data-tm-force-width-spacing-trimmed'), null);
+    });
+
+    test('absolute sidebar columns are flattened so article content can use full mobile width', () => {
+        const { harness } = executeForceMobileView('https://daringfireball.net/2026/03/your_frustration_is_the_product', {
+            computedStyle(element) {
+                if (element.id === 'Sidebar') {
+                    return {
+                        fontSize: '16px',
+                        lineHeight: '22px',
+                        width: '160px',
+                        position: 'absolute',
+                        float: 'none',
+                        left: '0px',
+                        right: 'auto',
+                        marginLeft: '16px',
+                        marginRight: '0px',
+                        paddingLeft: '16px',
+                        paddingRight: '8px'
+                    };
+                }
+                if (element.id === 'Main') {
+                    return {
+                        fontSize: '16px',
+                        lineHeight: '22px',
+                        width: '425px',
+                        position: 'relative',
+                        float: 'none',
+                        left: '0px',
+                        right: 'auto',
+                        marginLeft: '222px',
+                        marginRight: '0px',
+                        paddingLeft: '0px',
+                        paddingRight: '0px'
+                    };
+                }
+                return {
+                    fontSize: '16px',
+                    lineHeight: '22px',
+                    width: '360px',
+                    position: 'static',
+                    float: 'none',
+                    left: 'auto',
+                    right: 'auto',
+                    marginLeft: '0px',
+                    marginRight: '0px',
+                    paddingLeft: '0px',
+                    paddingRight: '0px'
+                };
+            }
+        });
+        const sidebar = harness.document.createElement('aside');
+        sidebar.id = 'Sidebar';
+        ['Archive', 'The Talk Show', 'Dithering'].forEach((label) => {
+            const link = harness.document.createElement('a');
+            link.href = '#';
+            link.textContent = label;
+            sidebar.appendChild(link);
+        });
+        const main = harness.document.createElement('main');
+        main.id = 'Main';
+        main.textContent = 'Article text';
+        harness.appendToBody(sidebar);
+        harness.appendToBody(main);
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        assert.equal(sidebar.style.getPropertyValue('position'), 'static');
+        assert.equal(sidebar.style.getPropertyValue('width'), 'auto');
+        assert.equal(sidebar.style.getPropertyValue('max-width'), '100%');
+        assert.equal(main.style.getPropertyValue('margin-left'), '0px');
     });
 
     test('legacy font-only boost overlaps text lines, while current behavior raises parent line-height', () => {

--- a/scripts/test-force-mobile-view.js
+++ b/scripts/test-force-mobile-view.js
@@ -164,8 +164,14 @@ describe('ForceMobileView on captured pages', () => {
         const button = harness.document.body.children.find((child) => child.tagName === 'BUTTON' && child.textContent === '↔');
 
         assert.equal(post.style.getPropertyValue('margin-left'), '0px');
-        assert.equal(post.style.getPropertyValue('padding-left'), '8px');
+        assert.equal(post.style.getPropertyValue('padding-left'), '2px');
+        assert.equal(post.style.getPropertyValue('padding-right'), '2px');
         assert.equal(post.getAttribute('data-tm-force-width-spacing-trimmed'), 'true');
+        const totalSideWhitespace = Number.parseFloat(post.style.getPropertyValue('margin-left') || '0') +
+            Number.parseFloat(post.style.getPropertyValue('margin-right') || '0') +
+            Number.parseFloat(post.style.getPropertyValue('padding-left') || '0') +
+            Number.parseFloat(post.style.getPropertyValue('padding-right') || '0');
+        assert(totalSideWhitespace <= 4, 'Expected side whitespace to stay minimal on narrow mobile screens.');
 
         button.click();
         assert.equal(post.style.getPropertyValue('margin-left'), '');

--- a/scripts/test-force-mobile-view.js
+++ b/scripts/test-force-mobile-view.js
@@ -48,10 +48,6 @@ function executeForceMobileView(url, options = {}) {
             }
             return {
                 fontSize: element.tagName === 'SPAN' ? '10px' : '16px',
-                lineHeight: '22px',
-                width: '360px',
-                position: 'static',
-                float: 'none',
                 marginLeft: '0px',
                 marginRight: '0px',
                 paddingLeft: '0px',
@@ -152,10 +148,6 @@ describe('ForceMobileView on captured pages', () => {
             computedStyle(element) {
                 return {
                     fontSize: '16px',
-                    lineHeight: '22px',
-                    width: element.id === 'post' ? '320px' : '360px',
-                    position: 'static',
-                    float: 'none',
                     marginLeft: element.id === 'post' ? '24px' : '0px',
                     marginRight: element.id === 'post' ? '24px' : '0px',
                     paddingLeft: element.id === 'post' ? '18px' : '0px',
@@ -172,88 +164,13 @@ describe('ForceMobileView on captured pages', () => {
         const button = harness.document.body.children.find((child) => child.tagName === 'BUTTON' && child.textContent === '↔');
 
         assert.equal(post.style.getPropertyValue('margin-left'), '0px');
-        assert.equal(post.style.getPropertyValue('padding-left'), '2px');
-        assert.equal(post.style.getPropertyValue('padding-right'), '2px');
+        assert.equal(post.style.getPropertyValue('padding-left'), '8px');
         assert.equal(post.getAttribute('data-tm-force-width-spacing-trimmed'), 'true');
-        const totalSideWhitespace = Number.parseFloat(post.style.getPropertyValue('margin-left') || '0') +
-            Number.parseFloat(post.style.getPropertyValue('margin-right') || '0') +
-            Number.parseFloat(post.style.getPropertyValue('padding-left') || '0') +
-            Number.parseFloat(post.style.getPropertyValue('padding-right') || '0');
-        assert(totalSideWhitespace <= 4, 'Expected side whitespace to stay minimal on narrow mobile screens.');
 
         button.click();
         assert.equal(post.style.getPropertyValue('margin-left'), '');
         assert.equal(post.style.getPropertyValue('padding-left'), '');
         assert.equal(post.getAttribute('data-tm-force-width-spacing-trimmed'), null);
-    });
-
-    test('absolute sidebar columns are flattened so article content can use full mobile width', () => {
-        const { harness } = executeForceMobileView('https://daringfireball.net/2026/03/your_frustration_is_the_product', {
-            computedStyle(element) {
-                if (element.id === 'Sidebar') {
-                    return {
-                        fontSize: '16px',
-                        lineHeight: '22px',
-                        width: '160px',
-                        position: 'absolute',
-                        float: 'none',
-                        left: '0px',
-                        right: 'auto',
-                        marginLeft: '16px',
-                        marginRight: '0px',
-                        paddingLeft: '16px',
-                        paddingRight: '8px'
-                    };
-                }
-                if (element.id === 'Main') {
-                    return {
-                        fontSize: '16px',
-                        lineHeight: '22px',
-                        width: '425px',
-                        position: 'relative',
-                        float: 'none',
-                        left: '0px',
-                        right: 'auto',
-                        marginLeft: '222px',
-                        marginRight: '0px',
-                        paddingLeft: '0px',
-                        paddingRight: '0px'
-                    };
-                }
-                return {
-                    fontSize: '16px',
-                    lineHeight: '22px',
-                    width: '360px',
-                    position: 'static',
-                    float: 'none',
-                    left: 'auto',
-                    right: 'auto',
-                    marginLeft: '0px',
-                    marginRight: '0px',
-                    paddingLeft: '0px',
-                    paddingRight: '0px'
-                };
-            }
-        });
-        const sidebar = harness.document.createElement('aside');
-        sidebar.id = 'Sidebar';
-        ['Archive', 'The Talk Show', 'Dithering'].forEach((label) => {
-            const link = harness.document.createElement('a');
-            link.href = '#';
-            link.textContent = label;
-            sidebar.appendChild(link);
-        });
-        const main = harness.document.createElement('main');
-        main.id = 'Main';
-        main.textContent = 'Article text';
-        harness.appendToBody(sidebar);
-        harness.appendToBody(main);
-        harness.dispatchDocumentEvent('DOMContentLoaded');
-
-        assert.equal(sidebar.style.getPropertyValue('position'), 'static');
-        assert.equal(sidebar.style.getPropertyValue('width'), 'auto');
-        assert.equal(sidebar.style.getPropertyValue('max-width'), '100%');
-        assert.equal(main.style.getPropertyValue('margin-left'), '0px');
     });
 
     test('legacy font-only boost overlaps text lines, while current behavior raises parent line-height', () => {

--- a/src/ForceMobileView.user.js
+++ b/src/ForceMobileView.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Force Mobile View
 // @namespace    http://tampermonkey.net/
-// @version      2026-03-19_1.6.0
+// @version      2026-04-12_1.7.0
 // @description  Keep pages within the viewport width, trim excessive horizontal spacing on all enabled pages, wrap long content, and expose a draggable top-right ↔ toggle button with auto-enable for matched URLs or tiny fonts.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -29,6 +29,9 @@
     const MIN_FONT_PRIORITY_ATTR = 'data-tm-force-width-font-priority';
     const MIN_LINE_HEIGHT_VALUE_ATTR = 'data-tm-force-width-line-height-value';
     const MIN_LINE_HEIGHT_PRIORITY_ATTR = 'data-tm-force-width-line-height-priority';
+    const MIN_LINE_HEIGHT_ONLY_FLAG_ATTR = 'data-tm-force-width-min-line-height-only';
+    const MIN_LINE_HEIGHT_ONLY_VALUE_ATTR = 'data-tm-force-width-min-line-height-only-value';
+    const MIN_LINE_HEIGHT_ONLY_PRIORITY_ATTR = 'data-tm-force-width-min-line-height-only-priority';
     const SPACING_FLAG_ATTR = 'data-tm-force-width-spacing-trimmed';
     const SPACING_MARGIN_LEFT_ATTR = 'data-tm-force-width-margin-left';
     const SPACING_MARGIN_LEFT_PRIORITY_ATTR = 'data-tm-force-width-margin-left-priority';
@@ -394,6 +397,7 @@
         if (!root || !Number.isFinite(minFontSizePx)) {
             return;
         }
+        const enforcedAncestors = new Set();
         const elements = [];
         if (root.nodeType === Node.ELEMENT_NODE) {
             elements.push(root);
@@ -417,8 +421,39 @@
             element.setAttribute(MIN_LINE_HEIGHT_VALUE_ATTR, lineHeightValue);
             element.setAttribute(MIN_LINE_HEIGHT_PRIORITY_ATTR, lineHeightPriority);
             element.style.setProperty('font-size', `${minFontSizePx}px`, 'important');
-            element.style.setProperty('line-height', String(MIN_LINE_HEIGHT_RATIO), 'important');
+            const minimumLineHeightPx = minFontSizePx * MIN_LINE_HEIGHT_RATIO;
+            element.style.setProperty('line-height', `${minimumLineHeightPx}px`, 'important');
+            let parent = element.parentElement;
+            while (parent && parent !== document.documentElement) {
+                if (!enforcedAncestors.has(parent)) {
+                    enforceReadableLineHeight(parent);
+                    enforcedAncestors.add(parent);
+                }
+                parent = parent.parentElement;
+            }
         });
+    }
+
+    function enforceReadableLineHeight(element) {
+        if (!element || element.hasAttribute(MIN_FONT_FLAG_ATTR) || element.hasAttribute(MIN_LINE_HEIGHT_ONLY_FLAG_ATTR)) {
+            return;
+        }
+        const computedStyle = window.getComputedStyle(element);
+        const computedFontSize = Number.parseFloat(computedStyle.fontSize);
+        const computedLineHeight = Number.parseFloat(computedStyle.lineHeight);
+        if (!Number.isFinite(computedFontSize) || !Number.isFinite(computedLineHeight)) {
+            return;
+        }
+        const minimumLineHeightPx = computedFontSize * MIN_LINE_HEIGHT_RATIO;
+        if (computedLineHeight >= minimumLineHeightPx) {
+            return;
+        }
+        const lineHeightValue = element.style.getPropertyValue('line-height');
+        const lineHeightPriority = element.style.getPropertyPriority('line-height');
+        element.setAttribute(MIN_LINE_HEIGHT_ONLY_FLAG_ATTR, 'true');
+        element.setAttribute(MIN_LINE_HEIGHT_ONLY_VALUE_ATTR, lineHeightValue);
+        element.setAttribute(MIN_LINE_HEIGHT_ONLY_PRIORITY_ATTR, lineHeightPriority);
+        element.style.setProperty('line-height', `${minimumLineHeightPx}px`, 'important');
     }
 
     function clearMinimumFontSize() {
@@ -443,6 +478,19 @@
             element.removeAttribute(MIN_FONT_PRIORITY_ATTR);
             element.removeAttribute(MIN_LINE_HEIGHT_VALUE_ATTR);
             element.removeAttribute(MIN_LINE_HEIGHT_PRIORITY_ATTR);
+        });
+        const lineHeightOnlyElements = document.querySelectorAll(`[${MIN_LINE_HEIGHT_ONLY_FLAG_ATTR}="true"]`);
+        lineHeightOnlyElements.forEach((element) => {
+            const lineHeightValue = element.getAttribute(MIN_LINE_HEIGHT_ONLY_VALUE_ATTR) || '';
+            const lineHeightPriority = element.getAttribute(MIN_LINE_HEIGHT_ONLY_PRIORITY_ATTR) || '';
+            if (lineHeightValue) {
+                element.style.setProperty('line-height', lineHeightValue, lineHeightPriority);
+            } else {
+                element.style.removeProperty('line-height');
+            }
+            element.removeAttribute(MIN_LINE_HEIGHT_ONLY_FLAG_ATTR);
+            element.removeAttribute(MIN_LINE_HEIGHT_ONLY_VALUE_ATTR);
+            element.removeAttribute(MIN_LINE_HEIGHT_ONLY_PRIORITY_ATTR);
         });
     }
 

--- a/src/ForceMobileView.user.js
+++ b/src/ForceMobileView.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Force Mobile View
 // @namespace    http://tampermonkey.net/
-// @version      2026-04-12_1.7.0
+// @version      2026-04-12_1.7.1
 // @description  Keep pages within the viewport width, trim excessive horizontal spacing on all enabled pages, wrap long content, and expose a draggable top-right ↔ toggle button with auto-enable for matched URLs or tiny fonts.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -42,7 +42,7 @@
     const SPACING_PADDING_RIGHT_ATTR = 'data-tm-force-width-padding-right';
     const SPACING_PADDING_RIGHT_PRIORITY_ATTR = 'data-tm-force-width-padding-right-priority';
     const SPACING_TARGET_SELECTOR = 'main, article, section, div, aside, header, footer, nav, ul, ol, li, p, blockquote, pre, figure, table';
-    const MAX_SIDE_SPACING_PX = 8;
+    const MAX_SIDE_SPACING_PX = 2;
     let isEnabled = false;
     let styleObserver;
     let isObserving = false;
@@ -73,8 +73,8 @@
             `    body > * {\n` +
             `        margin-left: 0 !important;\n` +
             `        margin-right: 0 !important;\n` +
-            `        padding-left: min(2vw, 8px) !important;\n` +
-            `        padding-right: min(2vw, 8px) !important;\n` +
+            `        padding-left: min(0.6vw, 2px) !important;\n` +
+            `        padding-right: min(0.6vw, 2px) !important;\n` +
             `    }\n` +
             `}\n` +
             `body * {\n` +

--- a/src/ForceMobileView.user.js
+++ b/src/ForceMobileView.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Force Mobile View
 // @namespace    http://tampermonkey.net/
-// @version      2026-04-12_1.7.2
+// @version      2026-04-12_1.7.1
 // @description  Keep pages within the viewport width, trim excessive horizontal spacing on all enabled pages, wrap long content, and expose a draggable top-right ↔ toggle button with auto-enable for matched URLs or tiny fonts.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -42,7 +42,7 @@
     const SPACING_PADDING_RIGHT_ATTR = 'data-tm-force-width-padding-right';
     const SPACING_PADDING_RIGHT_PRIORITY_ATTR = 'data-tm-force-width-padding-right-priority';
     const SPACING_TARGET_SELECTOR = 'main, article, section, div, aside, header, footer, nav, ul, ol, li, p, blockquote, pre, figure, table';
-    const MAX_SIDE_SPACING_PX = 8;
+    const MAX_SIDE_SPACING_PX = 2;
     let isEnabled = false;
     let styleObserver;
     let isObserving = false;
@@ -73,8 +73,8 @@
             `    body > * {\n` +
             `        margin-left: 0 !important;\n` +
             `        margin-right: 0 !important;\n` +
-            `        padding-left: min(2vw, 8px) !important;\n` +
-            `        padding-right: min(2vw, 8px) !important;\n` +
+            `        padding-left: min(0.6vw, 2px) !important;\n` +
+            `        padding-right: min(0.6vw, 2px) !important;\n` +
             `    }\n` +
             `}\n` +
             `body * {\n` +
@@ -322,7 +322,6 @@
             element.style.setProperty('margin-right', '0px', 'important');
             element.style.setProperty('padding-left', `${MAX_SIDE_SPACING_PX}px`, 'important');
             element.style.setProperty('padding-right', `${MAX_SIDE_SPACING_PX}px`, 'important');
-
         });
     }
 

--- a/src/ForceMobileView.user.js
+++ b/src/ForceMobileView.user.js
@@ -41,6 +41,20 @@
     const SPACING_PADDING_LEFT_PRIORITY_ATTR = 'data-tm-force-width-padding-left-priority';
     const SPACING_PADDING_RIGHT_ATTR = 'data-tm-force-width-padding-right';
     const SPACING_PADDING_RIGHT_PRIORITY_ATTR = 'data-tm-force-width-padding-right-priority';
+    const LAYOUT_POSITION_ATTR = 'data-tm-force-width-position';
+    const LAYOUT_POSITION_PRIORITY_ATTR = 'data-tm-force-width-position-priority';
+    const LAYOUT_FLOAT_ATTR = 'data-tm-force-width-float';
+    const LAYOUT_FLOAT_PRIORITY_ATTR = 'data-tm-force-width-float-priority';
+    const LAYOUT_LEFT_ATTR = 'data-tm-force-width-left';
+    const LAYOUT_LEFT_PRIORITY_ATTR = 'data-tm-force-width-left-priority';
+    const LAYOUT_RIGHT_ATTR = 'data-tm-force-width-right';
+    const LAYOUT_RIGHT_PRIORITY_ATTR = 'data-tm-force-width-right-priority';
+    const LAYOUT_WIDTH_ATTR = 'data-tm-force-width-width';
+    const LAYOUT_WIDTH_PRIORITY_ATTR = 'data-tm-force-width-width-priority';
+    const LAYOUT_MAX_WIDTH_ATTR = 'data-tm-force-width-max-width';
+    const LAYOUT_MAX_WIDTH_PRIORITY_ATTR = 'data-tm-force-width-max-width-priority';
+    const LAYOUT_TRANSFORM_ATTR = 'data-tm-force-width-transform';
+    const LAYOUT_TRANSFORM_PRIORITY_ATTR = 'data-tm-force-width-transform-priority';
     const SPACING_TARGET_SELECTOR = 'main, article, section, div, aside, header, footer, nav, ul, ol, li, p, blockquote, pre, figure, table';
     const MAX_SIDE_SPACING_PX = 2;
     let isEnabled = false;
@@ -290,6 +304,7 @@
         if (!root || !shouldEnforceMinFontSize()) {
             return;
         }
+        const viewportWidth = getContentWidthPx();
         const elements = getElementsForSpacingNormalization(root);
         elements.forEach((element) => {
             if (element.hasAttribute(SPACING_FLAG_ATTR)) {
@@ -322,7 +337,39 @@
             element.style.setProperty('margin-right', '0px', 'important');
             element.style.setProperty('padding-left', `${MAX_SIDE_SPACING_PX}px`, 'important');
             element.style.setProperty('padding-right', `${MAX_SIDE_SPACING_PX}px`, 'important');
+
+            if (isSidebarLikeElement(element, computedStyle, viewportWidth)) {
+                storeLayoutProperty(element, 'position', LAYOUT_POSITION_ATTR, LAYOUT_POSITION_PRIORITY_ATTR);
+                storeLayoutProperty(element, 'float', LAYOUT_FLOAT_ATTR, LAYOUT_FLOAT_PRIORITY_ATTR);
+                storeLayoutProperty(element, 'left', LAYOUT_LEFT_ATTR, LAYOUT_LEFT_PRIORITY_ATTR);
+                storeLayoutProperty(element, 'right', LAYOUT_RIGHT_ATTR, LAYOUT_RIGHT_PRIORITY_ATTR);
+                storeLayoutProperty(element, 'width', LAYOUT_WIDTH_ATTR, LAYOUT_WIDTH_PRIORITY_ATTR);
+                storeLayoutProperty(element, 'max-width', LAYOUT_MAX_WIDTH_ATTR, LAYOUT_MAX_WIDTH_PRIORITY_ATTR);
+                storeLayoutProperty(element, 'transform', LAYOUT_TRANSFORM_ATTR, LAYOUT_TRANSFORM_PRIORITY_ATTR);
+                element.style.setProperty('position', 'static', 'important');
+                element.style.setProperty('float', 'none', 'important');
+                element.style.setProperty('left', 'auto', 'important');
+                element.style.setProperty('right', 'auto', 'important');
+                element.style.setProperty('width', 'auto', 'important');
+                element.style.setProperty('max-width', '100%', 'important');
+                element.style.setProperty('transform', 'none', 'important');
+            }
         });
+    }
+
+    function isSidebarLikeElement(element, computedStyle, viewportWidth) {
+        if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
+            return false;
+        }
+        const widthPx = getSidePixels(computedStyle.width);
+        const hasLinks = element.querySelectorAll('a').length >= 3;
+        const isOverlayColumn = computedStyle.position === 'absolute' || computedStyle.position === 'fixed' || computedStyle.float !== 'none';
+        return isOverlayColumn && hasLinks && widthPx > 0 && widthPx <= viewportWidth * 0.6;
+    }
+
+    function storeLayoutProperty(element, propertyName, valueAttr, priorityAttr) {
+        element.setAttribute(valueAttr, element.style.getPropertyValue(propertyName));
+        element.setAttribute(priorityAttr, element.style.getPropertyPriority(propertyName));
     }
 
     function scheduleMinimumFontRefresh() {
@@ -513,6 +560,13 @@
             restoreInlineProperty(element, 'margin-right', SPACING_MARGIN_RIGHT_ATTR, SPACING_MARGIN_RIGHT_PRIORITY_ATTR);
             restoreInlineProperty(element, 'padding-left', SPACING_PADDING_LEFT_ATTR, SPACING_PADDING_LEFT_PRIORITY_ATTR);
             restoreInlineProperty(element, 'padding-right', SPACING_PADDING_RIGHT_ATTR, SPACING_PADDING_RIGHT_PRIORITY_ATTR);
+            restoreInlineProperty(element, 'position', LAYOUT_POSITION_ATTR, LAYOUT_POSITION_PRIORITY_ATTR);
+            restoreInlineProperty(element, 'float', LAYOUT_FLOAT_ATTR, LAYOUT_FLOAT_PRIORITY_ATTR);
+            restoreInlineProperty(element, 'left', LAYOUT_LEFT_ATTR, LAYOUT_LEFT_PRIORITY_ATTR);
+            restoreInlineProperty(element, 'right', LAYOUT_RIGHT_ATTR, LAYOUT_RIGHT_PRIORITY_ATTR);
+            restoreInlineProperty(element, 'width', LAYOUT_WIDTH_ATTR, LAYOUT_WIDTH_PRIORITY_ATTR);
+            restoreInlineProperty(element, 'max-width', LAYOUT_MAX_WIDTH_ATTR, LAYOUT_MAX_WIDTH_PRIORITY_ATTR);
+            restoreInlineProperty(element, 'transform', LAYOUT_TRANSFORM_ATTR, LAYOUT_TRANSFORM_PRIORITY_ATTR);
             element.removeAttribute(SPACING_FLAG_ATTR);
         });
     }

--- a/src/ForceMobileView.user.js
+++ b/src/ForceMobileView.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Force Mobile View
 // @namespace    http://tampermonkey.net/
-// @version      2026-04-12_1.7.1
+// @version      2026-04-12_1.7.2
 // @description  Keep pages within the viewport width, trim excessive horizontal spacing on all enabled pages, wrap long content, and expose a draggable top-right ↔ toggle button with auto-enable for matched URLs or tiny fonts.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -41,22 +41,8 @@
     const SPACING_PADDING_LEFT_PRIORITY_ATTR = 'data-tm-force-width-padding-left-priority';
     const SPACING_PADDING_RIGHT_ATTR = 'data-tm-force-width-padding-right';
     const SPACING_PADDING_RIGHT_PRIORITY_ATTR = 'data-tm-force-width-padding-right-priority';
-    const LAYOUT_POSITION_ATTR = 'data-tm-force-width-position';
-    const LAYOUT_POSITION_PRIORITY_ATTR = 'data-tm-force-width-position-priority';
-    const LAYOUT_FLOAT_ATTR = 'data-tm-force-width-float';
-    const LAYOUT_FLOAT_PRIORITY_ATTR = 'data-tm-force-width-float-priority';
-    const LAYOUT_LEFT_ATTR = 'data-tm-force-width-left';
-    const LAYOUT_LEFT_PRIORITY_ATTR = 'data-tm-force-width-left-priority';
-    const LAYOUT_RIGHT_ATTR = 'data-tm-force-width-right';
-    const LAYOUT_RIGHT_PRIORITY_ATTR = 'data-tm-force-width-right-priority';
-    const LAYOUT_WIDTH_ATTR = 'data-tm-force-width-width';
-    const LAYOUT_WIDTH_PRIORITY_ATTR = 'data-tm-force-width-width-priority';
-    const LAYOUT_MAX_WIDTH_ATTR = 'data-tm-force-width-max-width';
-    const LAYOUT_MAX_WIDTH_PRIORITY_ATTR = 'data-tm-force-width-max-width-priority';
-    const LAYOUT_TRANSFORM_ATTR = 'data-tm-force-width-transform';
-    const LAYOUT_TRANSFORM_PRIORITY_ATTR = 'data-tm-force-width-transform-priority';
     const SPACING_TARGET_SELECTOR = 'main, article, section, div, aside, header, footer, nav, ul, ol, li, p, blockquote, pre, figure, table';
-    const MAX_SIDE_SPACING_PX = 2;
+    const MAX_SIDE_SPACING_PX = 8;
     let isEnabled = false;
     let styleObserver;
     let isObserving = false;
@@ -87,8 +73,8 @@
             `    body > * {\n` +
             `        margin-left: 0 !important;\n` +
             `        margin-right: 0 !important;\n` +
-            `        padding-left: min(0.6vw, 2px) !important;\n` +
-            `        padding-right: min(0.6vw, 2px) !important;\n` +
+            `        padding-left: min(2vw, 8px) !important;\n` +
+            `        padding-right: min(2vw, 8px) !important;\n` +
             `    }\n` +
             `}\n` +
             `body * {\n` +
@@ -304,7 +290,6 @@
         if (!root || !shouldEnforceMinFontSize()) {
             return;
         }
-        const viewportWidth = getContentWidthPx();
         const elements = getElementsForSpacingNormalization(root);
         elements.forEach((element) => {
             if (element.hasAttribute(SPACING_FLAG_ATTR)) {
@@ -338,38 +323,7 @@
             element.style.setProperty('padding-left', `${MAX_SIDE_SPACING_PX}px`, 'important');
             element.style.setProperty('padding-right', `${MAX_SIDE_SPACING_PX}px`, 'important');
 
-            if (isSidebarLikeElement(element, computedStyle, viewportWidth)) {
-                storeLayoutProperty(element, 'position', LAYOUT_POSITION_ATTR, LAYOUT_POSITION_PRIORITY_ATTR);
-                storeLayoutProperty(element, 'float', LAYOUT_FLOAT_ATTR, LAYOUT_FLOAT_PRIORITY_ATTR);
-                storeLayoutProperty(element, 'left', LAYOUT_LEFT_ATTR, LAYOUT_LEFT_PRIORITY_ATTR);
-                storeLayoutProperty(element, 'right', LAYOUT_RIGHT_ATTR, LAYOUT_RIGHT_PRIORITY_ATTR);
-                storeLayoutProperty(element, 'width', LAYOUT_WIDTH_ATTR, LAYOUT_WIDTH_PRIORITY_ATTR);
-                storeLayoutProperty(element, 'max-width', LAYOUT_MAX_WIDTH_ATTR, LAYOUT_MAX_WIDTH_PRIORITY_ATTR);
-                storeLayoutProperty(element, 'transform', LAYOUT_TRANSFORM_ATTR, LAYOUT_TRANSFORM_PRIORITY_ATTR);
-                element.style.setProperty('position', 'static', 'important');
-                element.style.setProperty('float', 'none', 'important');
-                element.style.setProperty('left', 'auto', 'important');
-                element.style.setProperty('right', 'auto', 'important');
-                element.style.setProperty('width', 'auto', 'important');
-                element.style.setProperty('max-width', '100%', 'important');
-                element.style.setProperty('transform', 'none', 'important');
-            }
         });
-    }
-
-    function isSidebarLikeElement(element, computedStyle, viewportWidth) {
-        if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
-            return false;
-        }
-        const widthPx = getSidePixels(computedStyle.width);
-        const hasLinks = element.querySelectorAll('a').length >= 3;
-        const isOverlayColumn = computedStyle.position === 'absolute' || computedStyle.position === 'fixed' || computedStyle.float !== 'none';
-        return isOverlayColumn && hasLinks && widthPx > 0 && widthPx <= viewportWidth * 0.6;
-    }
-
-    function storeLayoutProperty(element, propertyName, valueAttr, priorityAttr) {
-        element.setAttribute(valueAttr, element.style.getPropertyValue(propertyName));
-        element.setAttribute(priorityAttr, element.style.getPropertyPriority(propertyName));
     }
 
     function scheduleMinimumFontRefresh() {
@@ -560,13 +514,6 @@
             restoreInlineProperty(element, 'margin-right', SPACING_MARGIN_RIGHT_ATTR, SPACING_MARGIN_RIGHT_PRIORITY_ATTR);
             restoreInlineProperty(element, 'padding-left', SPACING_PADDING_LEFT_ATTR, SPACING_PADDING_LEFT_PRIORITY_ATTR);
             restoreInlineProperty(element, 'padding-right', SPACING_PADDING_RIGHT_ATTR, SPACING_PADDING_RIGHT_PRIORITY_ATTR);
-            restoreInlineProperty(element, 'position', LAYOUT_POSITION_ATTR, LAYOUT_POSITION_PRIORITY_ATTR);
-            restoreInlineProperty(element, 'float', LAYOUT_FLOAT_ATTR, LAYOUT_FLOAT_PRIORITY_ATTR);
-            restoreInlineProperty(element, 'left', LAYOUT_LEFT_ATTR, LAYOUT_LEFT_PRIORITY_ATTR);
-            restoreInlineProperty(element, 'right', LAYOUT_RIGHT_ATTR, LAYOUT_RIGHT_PRIORITY_ATTR);
-            restoreInlineProperty(element, 'width', LAYOUT_WIDTH_ATTR, LAYOUT_WIDTH_PRIORITY_ATTR);
-            restoreInlineProperty(element, 'max-width', LAYOUT_MAX_WIDTH_ATTR, LAYOUT_MAX_WIDTH_PRIORITY_ATTR);
-            restoreInlineProperty(element, 'transform', LAYOUT_TRANSFORM_ATTR, LAYOUT_TRANSFORM_PRIORITY_ATTR);
             element.removeAttribute(SPACING_FLAG_ATTR);
         });
     }

--- a/tests/Force Mobile View/steveblank.com_2026_04_09_nowhere-is-safe.html
+++ b/tests/Force Mobile View/steveblank.com_2026_04_09_nowhere-is-safe.html
@@ -1,0 +1,1441 @@
+<!-- CONTENT_CLASS: VALID_ARTICLE_CONTENT | Accessible page includes primary article/content body. -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--[if IE 8]>
+<html id="ie8" xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
+<![endif]-->
+<!--[if !(IE 8)]><!-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
+<!--<![endif]-->
+<head profile="http://gmpg.org/xfn/11">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>Steve Blank Nowhere Is Safe</title>
+<link rel="pingback" href="https://steveblank.com/xmlrpc.php" />
+<meta name='robots' content='max-image-preview:large' />
+<!-- Jetpack Site Verification Tags -->
+<meta name="google-site-verification" content="NzQX03n5c3BUqAOH2ZZeaOzmFxIKopb99y0xo7ymJ7w" />
+<meta name="msvalidate.01" content="77BB8773D8C1446AC1C1A19B8355A369" />
+<link rel='dns-prefetch' href='//secure.gravatar.com' />
+<link rel='dns-prefetch' href='//stats.wp.com' />
+<link rel='dns-prefetch' href='//widgets.wp.com' />
+<link rel='dns-prefetch' href='//jetpack.wordpress.com' />
+<link rel='dns-prefetch' href='//s0.wp.com' />
+<link rel='dns-prefetch' href='//public-api.wordpress.com' />
+<link rel='dns-prefetch' href='//0.gravatar.com' />
+<link rel='dns-prefetch' href='//1.gravatar.com' />
+<link rel='dns-prefetch' href='//2.gravatar.com' />
+<link rel='preconnect' href='//i0.wp.com' />
+<link rel='preconnect' href='//c0.wp.com' />
+<link rel="alternate" type="application/rss+xml" title="Steve Blank &raquo; Feed" href="https://steveblank.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Steve Blank &raquo; Comments Feed" href="https://steveblank.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Steve Blank &raquo; Nowhere Is Safe Comments Feed" href="https://steveblank.com/2026/04/09/nowhere-is-safe/feed/" />
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://steveblank.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fsteveblank.com%2F2026%2F04%2F09%2Fnowhere-is-safe%2F" />
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://steveblank.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fsteveblank.com%2F2026%2F04%2F09%2Fnowhere-is-safe%2F&#038;format=xml" />
+<style id='wp-img-auto-sizes-contain-inline-css'>
+img:is([sizes=auto i],[sizes^="auto," i]){contain-intrinsic-size:3000px 1500px}
+/*# sourceURL=wp-img-auto-sizes-contain-inline-css */
+</style>
+<style id='wp-emoji-styles-inline-css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+/*# sourceURL=wp-emoji-styles-inline-css */
+</style>
+<style id='wp-block-library-inline-css'>
+:root{--wp-block-synced-color:#7a00df;--wp-block-synced-color--rgb:122,0,223;--wp-bound-block-color:var(--wp-block-synced-color);--wp-editor-canvas-background:#ddd;--wp-admin-theme-color:#007cba;--wp-admin-theme-color--rgb:0,124,186;--wp-admin-theme-color-darker-10:#006ba1;--wp-admin-theme-color-darker-10--rgb:0,107,160.5;--wp-admin-theme-color-darker-20:#005a87;--wp-admin-theme-color-darker-20--rgb:0,90,135;--wp-admin-border-width-focus:2px}@media (min-resolution:192dpi){:root{--wp-admin-border-width-focus:1.5px}}.wp-element-button{cursor:pointer}:root .has-very-light-gray-background-color{background-color:#eee}:root .has-very-dark-gray-background-color{background-color:#313131}:root .has-very-light-gray-color{color:#eee}:root .has-very-dark-gray-color{color:#313131}:root .has-vivid-green-cyan-to-vivid-cyan-blue-gradient-background{background:linear-gradient(135deg,#00d084,#0693e3)}:root .has-purple-crush-gradient-background{background:linear-gradient(135deg,#34e2e4,#4721fb 50%,#ab1dfe)}:root .has-hazy-dawn-gradient-background{background:linear-gradient(135deg,#faaca8,#dad0ec)}:root .has-subdued-olive-gradient-background{background:linear-gradient(135deg,#fafae1,#67a671)}:root .has-atomic-cream-gradient-background{background:linear-gradient(135deg,#fdd79a,#004a59)}:root .has-nightshade-gradient-background{background:linear-gradient(135deg,#330968,#31cdcf)}:root .has-midnight-gradient-background{background:linear-gradient(135deg,#020381,#2874fc)}:root{--wp--preset--font-size--normal:16px;--wp--preset--font-size--huge:42px}.has-regular-font-size{font-size:1em}.has-larger-font-size{font-size:2.625em}.has-normal-font-size{font-size:var(--wp--preset--font-size--normal)}.has-huge-font-size{font-size:var(--wp--preset--font-size--huge)}.has-text-align-center{text-align:center}.has-text-align-left{text-align:left}.has-text-align-right{text-align:right}.has-fit-text{white-space:nowrap!important}#end-resizable-editor-section{display:none}.aligncenter{clear:both}.items-justified-left{justify-content:flex-start}.items-justified-center{justify-content:center}.items-justified-right{justify-content:flex-end}.items-justified-space-between{justify-content:space-between}.screen-reader-text{border:0;clip-path:inset(50%);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px;word-wrap:normal!important}.screen-reader-text:focus{background-color:#ddd;clip-path:none;color:#444;display:block;font-size:1em;height:auto;left:5px;line-height:normal;padding:15px 23px 14px;text-decoration:none;top:5px;width:auto;z-index:100000}html :where(.has-border-color){border-style:solid}html :where([style*=border-top-color]){border-top-style:solid}html :where([style*=border-right-color]){border-right-style:solid}html :where([style*=border-bottom-color]){border-bottom-style:solid}html :where([style*=border-left-color]){border-left-style:solid}html :where([style*=border-width]){border-style:solid}html :where([style*=border-top-width]){border-top-style:solid}html :where([style*=border-right-width]){border-right-style:solid}html :where([style*=border-bottom-width]){border-bottom-style:solid}html :where([style*=border-left-width]){border-left-style:solid}html :where(img[class*=wp-image-]){height:auto;max-width:100%}:where(figure){margin:0 0 1em}html :where(.is-position-sticky){--wp-admin--admin-bar--position-offset:var(--wp-admin--admin-bar--height,0px)}@media screen and (max-width:600px){html :where(.is-position-sticky){--wp-admin--admin-bar--position-offset:0px}}
+.has-text-align-justify{text-align:justify;}
+
+/*# sourceURL=wp-block-library-inline-css */
+</style>
+<link rel='stylesheet' id='all-css-acc760d03b8539c2a24e08d241f775bb' href='https://steveblank.com/_static/??wp-includes/blocks/heading/style.min.css,wp-includes/blocks/group/style.min.css?m=1762259802' type='text/css' media='all' />
+<style id='wp-block-paragraph-inline-css'>
+.is-small-text{font-size:.875em}.is-regular-text{font-size:1em}.is-large-text{font-size:2.25em}.is-larger-text{font-size:3em}.has-drop-cap:not(:focus):first-letter{float:left;font-size:8.4em;font-style:normal;font-weight:100;line-height:.68;margin:.05em .1em 0 0;text-transform:uppercase}body.rtl .has-drop-cap:not(:focus):first-letter{float:none;margin-left:.1em}p.has-drop-cap.has-background{overflow:hidden}:root :where(p.has-background){padding:1.25em 2.375em}:where(p.has-text-color:not(.has-link-color)) a{color:inherit}p.has-text-align-left[style*="writing-mode:vertical-lr"],p.has-text-align-right[style*="writing-mode:vertical-rl"]{rotate:180deg}
+/*# sourceURL=https://steveblank.com/wp-includes/blocks/paragraph/style.min.css */
+</style>
+
+<style id='classic-theme-styles-inline-css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+/*# sourceURL=/wp-includes/css/classic-themes.min.css */
+</style>
+<style id='global-styles-inline-css'>
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgb(252,185,0) 0%,rgb(255,105,0) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgb(255,105,0) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--font-family--albert-sans: 'Albert Sans', sans-serif;--wp--preset--font-family--alegreya: Alegreya, serif;--wp--preset--font-family--arvo: Arvo, serif;--wp--preset--font-family--bodoni-moda: 'Bodoni Moda', serif;--wp--preset--font-family--bricolage-grotesque: 'Bricolage Grotesque', sans-serif;--wp--preset--font-family--cabin: Cabin, sans-serif;--wp--preset--font-family--chivo: Chivo, sans-serif;--wp--preset--font-family--commissioner: Commissioner, sans-serif;--wp--preset--font-family--cormorant: Cormorant, serif;--wp--preset--font-family--courier-prime: 'Courier Prime', monospace;--wp--preset--font-family--crimson-pro: 'Crimson Pro', serif;--wp--preset--font-family--dm-mono: 'DM Mono', monospace;--wp--preset--font-family--dm-sans: 'DM Sans', sans-serif;--wp--preset--font-family--dm-serif-display: 'DM Serif Display', serif;--wp--preset--font-family--domine: Domine, serif;--wp--preset--font-family--eb-garamond: 'EB Garamond', serif;--wp--preset--font-family--epilogue: Epilogue, sans-serif;--wp--preset--font-family--fahkwang: Fahkwang, sans-serif;--wp--preset--font-family--figtree: Figtree, sans-serif;--wp--preset--font-family--fira-sans: 'Fira Sans', sans-serif;--wp--preset--font-family--fjalla-one: 'Fjalla One', sans-serif;--wp--preset--font-family--fraunces: Fraunces, serif;--wp--preset--font-family--gabarito: Gabarito, system-ui;--wp--preset--font-family--ibm-plex-mono: 'IBM Plex Mono', monospace;--wp--preset--font-family--ibm-plex-sans: 'IBM Plex Sans', sans-serif;--wp--preset--font-family--ibarra-real-nova: 'Ibarra Real Nova', serif;--wp--preset--font-family--instrument-serif: 'Instrument Serif', serif;--wp--preset--font-family--inter: Inter, sans-serif;--wp--preset--font-family--josefin-sans: 'Josefin Sans', sans-serif;--wp--preset--font-family--jost: Jost, sans-serif;--wp--preset--font-family--libre-baskerville: 'Libre Baskerville', serif;--wp--preset--font-family--libre-franklin: 'Libre Franklin', sans-serif;--wp--preset--font-family--literata: Literata, serif;--wp--preset--font-family--lora: Lora, serif;--wp--preset--font-family--merriweather: Merriweather, serif;--wp--preset--font-family--montserrat: Montserrat, sans-serif;--wp--preset--font-family--newsreader: Newsreader, serif;--wp--preset--font-family--noto-sans-mono: 'Noto Sans Mono', sans-serif;--wp--preset--font-family--nunito: Nunito, sans-serif;--wp--preset--font-family--open-sans: 'Open Sans', sans-serif;--wp--preset--font-family--overpass: Overpass, sans-serif;--wp--preset--font-family--pt-serif: 'PT Serif', serif;--wp--preset--font-family--petrona: Petrona, serif;--wp--preset--font-family--piazzolla: Piazzolla, serif;--wp--preset--font-family--playfair-display: 'Playfair Display', serif;--wp--preset--font-family--plus-jakarta-sans: 'Plus Jakarta Sans', sans-serif;--wp--preset--font-family--poppins: Poppins, sans-serif;--wp--preset--font-family--raleway: Raleway, sans-serif;--wp--preset--font-family--roboto: Roboto, sans-serif;--wp--preset--font-family--roboto-slab: 'Roboto Slab', serif;--wp--preset--font-family--rubik: Rubik, sans-serif;--wp--preset--font-family--rufina: Rufina, serif;--wp--preset--font-family--sora: Sora, sans-serif;--wp--preset--font-family--source-sans-3: 'Source Sans 3', sans-serif;--wp--preset--font-family--source-serif-4: 'Source Serif 4', serif;--wp--preset--font-family--space-mono: 'Space Mono', monospace;--wp--preset--font-family--syne: Syne, sans-serif;--wp--preset--font-family--texturina: Texturina, serif;--wp--preset--font-family--urbanist: Urbanist, sans-serif;--wp--preset--font-family--work-sans: 'Work Sans', sans-serif;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0);--wp--preset--shadow--crisp: 6px 6px 0px rgb(0, 0, 0);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}.has-albert-sans-font-family{font-family: var(--wp--preset--font-family--albert-sans) !important;}.has-alegreya-font-family{font-family: var(--wp--preset--font-family--alegreya) !important;}.has-arvo-font-family{font-family: var(--wp--preset--font-family--arvo) !important;}.has-bodoni-moda-font-family{font-family: var(--wp--preset--font-family--bodoni-moda) !important;}.has-bricolage-grotesque-font-family{font-family: var(--wp--preset--font-family--bricolage-grotesque) !important;}.has-cabin-font-family{font-family: var(--wp--preset--font-family--cabin) !important;}.has-chivo-font-family{font-family: var(--wp--preset--font-family--chivo) !important;}.has-commissioner-font-family{font-family: var(--wp--preset--font-family--commissioner) !important;}.has-cormorant-font-family{font-family: var(--wp--preset--font-family--cormorant) !important;}.has-courier-prime-font-family{font-family: var(--wp--preset--font-family--courier-prime) !important;}.has-crimson-pro-font-family{font-family: var(--wp--preset--font-family--crimson-pro) !important;}.has-dm-mono-font-family{font-family: var(--wp--preset--font-family--dm-mono) !important;}.has-dm-sans-font-family{font-family: var(--wp--preset--font-family--dm-sans) !important;}.has-dm-serif-display-font-family{font-family: var(--wp--preset--font-family--dm-serif-display) !important;}.has-domine-font-family{font-family: var(--wp--preset--font-family--domine) !important;}.has-eb-garamond-font-family{font-family: var(--wp--preset--font-family--eb-garamond) !important;}.has-epilogue-font-family{font-family: var(--wp--preset--font-family--epilogue) !important;}.has-fahkwang-font-family{font-family: var(--wp--preset--font-family--fahkwang) !important;}.has-figtree-font-family{font-family: var(--wp--preset--font-family--figtree) !important;}.has-fira-sans-font-family{font-family: var(--wp--preset--font-family--fira-sans) !important;}.has-fjalla-one-font-family{font-family: var(--wp--preset--font-family--fjalla-one) !important;}.has-fraunces-font-family{font-family: var(--wp--preset--font-family--fraunces) !important;}.has-gabarito-font-family{font-family: var(--wp--preset--font-family--gabarito) !important;}.has-ibm-plex-mono-font-family{font-family: var(--wp--preset--font-family--ibm-plex-mono) !important;}.has-ibm-plex-sans-font-family{font-family: var(--wp--preset--font-family--ibm-plex-sans) !important;}.has-ibarra-real-nova-font-family{font-family: var(--wp--preset--font-family--ibarra-real-nova) !important;}.has-instrument-serif-font-family{font-family: var(--wp--preset--font-family--instrument-serif) !important;}.has-inter-font-family{font-family: var(--wp--preset--font-family--inter) !important;}.has-josefin-sans-font-family{font-family: var(--wp--preset--font-family--josefin-sans) !important;}.has-jost-font-family{font-family: var(--wp--preset--font-family--jost) !important;}.has-libre-baskerville-font-family{font-family: var(--wp--preset--font-family--libre-baskerville) !important;}.has-libre-franklin-font-family{font-family: var(--wp--preset--font-family--libre-franklin) !important;}.has-literata-font-family{font-family: var(--wp--preset--font-family--literata) !important;}.has-lora-font-family{font-family: var(--wp--preset--font-family--lora) !important;}.has-merriweather-font-family{font-family: var(--wp--preset--font-family--merriweather) !important;}.has-montserrat-font-family{font-family: var(--wp--preset--font-family--montserrat) !important;}.has-newsreader-font-family{font-family: var(--wp--preset--font-family--newsreader) !important;}.has-noto-sans-mono-font-family{font-family: var(--wp--preset--font-family--noto-sans-mono) !important;}.has-nunito-font-family{font-family: var(--wp--preset--font-family--nunito) !important;}.has-open-sans-font-family{font-family: var(--wp--preset--font-family--open-sans) !important;}.has-overpass-font-family{font-family: var(--wp--preset--font-family--overpass) !important;}.has-pt-serif-font-family{font-family: var(--wp--preset--font-family--pt-serif) !important;}.has-petrona-font-family{font-family: var(--wp--preset--font-family--petrona) !important;}.has-piazzolla-font-family{font-family: var(--wp--preset--font-family--piazzolla) !important;}.has-playfair-display-font-family{font-family: var(--wp--preset--font-family--playfair-display) !important;}.has-plus-jakarta-sans-font-family{font-family: var(--wp--preset--font-family--plus-jakarta-sans) !important;}.has-poppins-font-family{font-family: var(--wp--preset--font-family--poppins) !important;}.has-raleway-font-family{font-family: var(--wp--preset--font-family--raleway) !important;}.has-roboto-font-family{font-family: var(--wp--preset--font-family--roboto) !important;}.has-roboto-slab-font-family{font-family: var(--wp--preset--font-family--roboto-slab) !important;}.has-rubik-font-family{font-family: var(--wp--preset--font-family--rubik) !important;}.has-rufina-font-family{font-family: var(--wp--preset--font-family--rufina) !important;}.has-sora-font-family{font-family: var(--wp--preset--font-family--sora) !important;}.has-source-sans-3-font-family{font-family: var(--wp--preset--font-family--source-sans-3) !important;}.has-source-serif-4-font-family{font-family: var(--wp--preset--font-family--source-serif-4) !important;}.has-space-mono-font-family{font-family: var(--wp--preset--font-family--space-mono) !important;}.has-syne-font-family{font-family: var(--wp--preset--font-family--syne) !important;}.has-texturina-font-family{font-family: var(--wp--preset--font-family--texturina) !important;}.has-urbanist-font-family{font-family: var(--wp--preset--font-family--urbanist) !important;}.has-work-sans-font-family{font-family: var(--wp--preset--font-family--work-sans) !important;}
+/*# sourceURL=global-styles-inline-css */
+</style>
+
+<link rel='stylesheet' id='all-css-6f9602dc0df3dc10c275f3ee9ac9e086' href='https://steveblank.com/_static/??wp-content/themes/digg3/style.css,wp-content/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.css?m=1764003632' type='text/css' media='all' />
+<style id='jetpack_likes-inline-css'>
+#jp-post-flair{padding-top:.5em}#content div.sharedaddy,#main div.sharedaddy,div.sharedaddy{clear:both}div.sharedaddy h3.sd-title{display:inline-block;font-size:9pt;font-weight:700;line-height:1.2;margin:0 0 1em}div.sharedaddy h3.sd-title:before{border-top:1px solid #dcdcde;content:"";display:block;margin-bottom:1em;min-width:30px;width:100%}div.jetpack-likes-widget-wrapper{min-height:50px;position:relative;width:100%}div.jetpack-likes-widget-wrapper .sd-link-color{font-size:12px}div.jetpack-comment-likes-widget-wrapper{min-height:31px;position:relative;width:100%}div.jetpack-comment-likes-widget-wrapper iframe{margin-bottom:0}#likes-other-gravatars{background-color:#fff;border:1px solid #dcdcde;border-radius:4px;box-shadow:none;display:none;height:auto;max-height:240px;min-width:220px;overflow:auto;padding:9px 12px 10px;position:absolute;z-index:1000}#likes-other-gravatars *{line-height:normal}#likes-other-gravatars .likes-text{color:#101517;font-size:12px;font-weight:500;padding-bottom:8px}#likes-other-gravatars li,#likes-other-gravatars ul{list-style-type:none;margin:0;padding:0;text-indent:0}#likes-other-gravatars li:before{content:""}#likes-other-gravatars ul.wpl-avatars{display:block;max-height:190px;overflow:auto}#likes-other-gravatars ul.wpl-avatars li{float:none;height:28px;margin:0 0 4px;width:196px}#likes-other-gravatars ul.wpl-avatars li a{align-items:center;border-bottom:none!important;display:flex;gap:8px;margin:0 2px 0 0;text-decoration:none}#likes-other-gravatars ul.wpl-avatars li a span{color:#2c3338;font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}#likes-other-gravatars ul.wpl-avatars li a img{background:none;border:none;border-radius:50%;box-sizing:border-box;margin:0!important;padding:1px!important;position:static}div.sd-box{border-top:1px solid #00000021}.jetpack-likes-widget-loaded iframe,.jetpack-likes-widget-loading .likes-widget-placeholder,.jetpack-likes-widget-unloaded .likes-widget-placeholder{display:block}.jetpack-likes-widget-loaded .likes-widget-placeholder,.jetpack-likes-widget-loading iframe,.jetpack-likes-widget-unloaded iframe{display:none}.comment-likes-widget,.entry-content .post-likes-widget,.post-likes-widget{border-width:0;margin:0}.comment-likes-widget-placeholder,.post-likes-widget-placeholder{border-width:0;margin:0;position:relative}.comment-likes-widget-placeholder{display:flex;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;height:18px;position:absolute}.comment-likes-widget-placeholder:before{background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath fill='%232ea2cc' d='m12 2 2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/svg%3E");background-repeat:no-repeat;background-size:16px 16px;color:#2ea2cc;content:"";display:inline-block;height:16px;padding-right:5px;position:relative;top:3px;width:16px}.post-likes-widget-placeholder .button{display:none}.comment-likes-widget-placeholder .loading,.post-likes-widget-placeholder .loading{color:#999;font-size:12px}.comment-likes-widget-placeholder .loading{align-self:center;color:#4e4e4e;margin-top:4px;padding-left:5px}div.sharedaddy.sd-like-enabled .sd-like h3{display:none}div.sharedaddy.sd-like-enabled .sd-like .post-likes-widget{float:none;position:absolute;top:0;width:100%}.comment-likes-widget{width:100%}.cs-rating,.pd-rating{display:block!important}.sd-gplus .sd-title{display:none}@media print{.jetpack-likes-widget-wrapper{display:none}}
+/*# sourceURL=https://steveblank.com/wp-content/plugins/jetpack/_inc/build/likes/style.min.css */
+</style>
+<link rel='stylesheet' id='jetpack-newsletter-reader-link-css' href='https://steveblank.com/wp-content/mu-plugins/wpcomsh/jetpack_vendor/automattic/jetpack-newsletter/src/../build/reader-link.css?ver=6569e23e23e0349e92b7' media='all' />
+<link rel='stylesheet' id='all-css-12ac3055038349d7e4a92052ae7f1e33' href='https://steveblank.com/wp-content/plugins/jetpack/_inc/build/subscriptions/subscriptions.min.css?m=1771329624' type='text/css' media='all' />
+<style id='jetpack-global-styles-frontend-style-inline-css'>
+:root { --font-headings: unset; --font-base: unset; --font-headings-default: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; --font-base-default: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;}
+/*# sourceURL=jetpack-global-styles-frontend-style-inline-css */
+</style>
+<link rel='stylesheet' id='all-css-ab4db740a1aa24d6dfd20ffe9387b366' href='https://steveblank.com/_static/??wp-content/plugins/jetpack/modules/sharedaddy/sharing.css,wp-content/plugins/jetpack/_inc/build/social-logos/social-logos.css?m=1774890128' type='text/css' media='all' />
+<script type="text/javascript" id="jetpack-mu-wpcom-settings-js-before">
+/* <![CDATA[ */
+var JETPACK_MU_WPCOM_SETTINGS = {"assetsUrl":"https://steveblank.com/wp-content/mu-plugins/wpcomsh/jetpack_vendor/automattic/jetpack-mu-wpcom/src/build/"};
+//# sourceURL=jetpack-mu-wpcom-settings-js-before
+/* ]]> */
+</script>
+<link rel="https://api.w.org/" href="https://steveblank.com/wp-json/" /><link rel="alternate" title="JSON" type="application/json" href="https://steveblank.com/wp-json/wp/v2/posts/33737" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://steveblank.com/xmlrpc.php?rsd" />
+
+<link rel="canonical" href="https://steveblank.com/2026/04/09/nowhere-is-safe/" />
+<link rel='shortlink' href='https://wp.me/prGQZ-8M9' />
+	<style>img#wpstats{display:none}</style>
+		<meta name="description" content="Drones in Ukraine and in the War with Iran have made the surface of the earth a contested space. The U.S. has discovered that 1) air superiority and missile defense systems (THAAD, Patriot batteries) designed to counter tens or hundreds of aircraft and missiles is insufficient against asymmetric attacks of thousands of drones. And that&hellip;" />
+<style type="text/css">
+#header h1 a, #header h1 a:hover, #header .description {
+color: #eb221e;
+}
+</style>
+<link rel="amphtml" href="https://steveblank.com/2026/04/09/nowhere-is-safe/amp/">
+<!-- Jetpack Open Graph Tags -->
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Steve Blank Nowhere Is Safe" />
+<meta property="og:url" content="https://steveblank.com/2026/04/09/nowhere-is-safe/" />
+<meta property="og:description" content="Drones in Ukraine and in the War with Iran have made the surface of the earth a contested space. The U.S. has discovered that 1) air superiority and missile defense systems (THAAD, Patriot batterie…" />
+<meta property="article:published_time" content="2026-04-09T13:00:25+00:00" />
+<meta property="article:modified_time" content="2026-04-10T21:13:55+00:00" />
+<meta property="og:site_name" content="Steve Blank" />
+<meta property="og:image" content="https://steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg" />
+<meta property="og:image:width" content="2816" />
+<meta property="og:image:height" content="1536" />
+<meta property="og:image:alt" content="" />
+<meta property="og:locale" content="en_US" />
+<meta name="twitter:text:title" content="Nowhere Is Safe" />
+<meta name="twitter:image" content="https://steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?w=640" />
+<meta name="twitter:card" content="summary_large_image" />
+
+<!-- End Jetpack Open Graph Tags -->
+<link rel="icon" href="https://s0.wp.com/i/webclip.png" sizes="32x32" />
+<link rel="icon" href="https://s0.wp.com/i/webclip.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://s0.wp.com/i/webclip.png" />
+<meta name="msapplication-TileImage" content="https://s0.wp.com/i/webclip.png" />
+<!-- Jetpack Google Analytics -->
+			<script type='text/javascript'>
+				var _gaq = _gaq || [];
+				_gaq.push(['_setAccount', 'UA-85363375-1']);
+_gaq.push(['_trackPageview']);
+				(function() {
+					var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+					ga.src = ('https:' === document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+				})();
+			</script>
+			<!-- End Jetpack Google Analytics -->
+<link rel='stylesheet' id='all-css-57212b92e4748cb8457915a952a9e7ab' href='https://steveblank.com/_static/??-eJx1jMsKgCAQAH8oW6SHXaJPidqWMJ+4ir8fHTx2nWGmRoHBZ/IZoi239gwP5XiggV17hNMGNAxcdaTUI3NX/wsXrmKJAY8UCpNtQjTwDTa3SqXkMg5qml9FDS9G' type='text/css' media='all' />
+<link rel='stylesheet' id='all-css-85f12ea0884ab942b1294ed9732846a7' href='https://steveblank.com/wp-content/plugins/jetpack/_inc/blocks/subscriptions/view.css?m=1764003632' type='text/css' media='all' />
+
+</head>
+<body class="wp-singular post-template-default single single-post postid-33737 single-format-standard wp-theme-digg3"><div id="container">
+
+<div id="header">
+
+	<div id="menu">
+		<ul id="menu-menu" class="menu"><li id="menu-item-12086" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-home menu-item-12086"><a href="http://steveblank.com">Home</a></li>
+<li id="menu-item-12085" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-12085"><a href="https://steveblank.com/about/">About Steve</a></li>
+<li id="menu-item-12083" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-12083"><a href="https://steveblank.com/books-for-startups/">Startup Books</a></li>
+<li id="menu-item-12080" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-12080"><a href="https://steveblank.com/slides/">Slides/Videos</a></li>
+<li id="menu-item-25611" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-25611"><a href="https://steveblank.com/raising-money/">Fund Raising</a></li>
+<li id="menu-item-12082" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-12082"><a href="https://steveblank.com/tools-and-blogs-for-entrepreneurs/">Tools!</a></li>
+<li id="menu-item-12084" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-12084"><a href="https://steveblank.com/secret-history/">Secret History</a></li>
+</ul>	</div>
+
+	<div id="header-box">
+	<div id="header-image">
+		<img src="https://steveblank.com/wp-content/uploads/2009/02/cropped-100_3947-ks-far-away-download10.jpg" alt="" />
+	</div>
+	<div id="header-overlay">
+		<img src="https://steveblank.com/wp-content/themes/digg3/images/bg_header_overlay.png" alt="" />
+	</div>
+
+	<div id="pagetitle">
+		<h1><a href="https://steveblank.com/" title="Steve Blank">Steve Blank</a></h1>
+	</div>
+
+	<div id="syndication">
+		<a href="https://steveblank.com/feed/" title="Syndicate this site using RSS" class="feed">Entries <abbr title="Really Simple Syndication">RSS</abbr></a> &#124; <a href="https://steveblank.com/comments/feed/" title="Syndicate comments using RSS">Comments RSS</a>
+	</div>
+	<div id="searchbox">
+		<form method="get" id="searchform" action="https://steveblank.com/">
+<div>
+	<input type="text" value="" name="s" id="s" />
+	<input type="submit" id="searchsubmit" value="Search" />
+</div>
+</form>	</div>
+	</div>
+</div>
+
+<div class="pagewrapper"><div id="page">
+
+<!-- Start Obar -->
+
+	<div class="obar">
+<ul>
+
+<li id="blog_subscription-3" class="widget widget_blog_subscription jetpack_subscription_widget"><h2 class="widgettitle">Email Subscription</h2>
+
+			<div class="wp-block-jetpack-subscriptions__container">
+			<form action="#" method="post" accept-charset="utf-8" id="subscribe-blog-blog_subscription-3"
+				data-blog="6599589"
+				data-post_access_level="everybody" >
+									<div id="subscribe-text"><p>Enter your email address to subscribe to this blog and receive notifications of new posts by email.</p>
+</div>
+										<p id="subscribe-email">
+						<label id="jetpack-subscribe-label"
+							class="screen-reader-text"
+							for="subscribe-field-blog_subscription-3">
+							Email Address						</label>
+						<input type="email" name="email" autocomplete="email" required="required"
+																					value=""
+							id="subscribe-field-blog_subscription-3"
+							placeholder="Email Address"
+						/>
+					</p>
+
+					<p id="subscribe-submit"
+											>
+						<input type="hidden" name="action" value="subscribe"/>
+						<input type="hidden" name="source" value="https://steveblank.com/2026/04/09/nowhere-is-safe/"/>
+						<input type="hidden" name="sub-type" value="widget"/>
+						<input type="hidden" name="redirect_fragment" value="subscribe-blog-blog_subscription-3"/>
+						<input type="hidden" id="_wpnonce" name="_wpnonce" value="d9a58a43d8" /><input type="hidden" name="_wp_http_referer" value="/2026/04/09/nowhere-is-safe/" />						<button type="submit"
+															class="wp-block-button__link"
+																					name="jetpack_subscriptions_widget"
+						>
+							Sign me up!						</button>
+					</p>
+							</form>
+							<div class="wp-block-jetpack-subscriptions__subscount">
+					Join 55.7K other subscribers				</div>
+						</div>
+			
+</li>
+<li id="categories-356180491" class="widget widget_categories"><h2 class="widgettitle">Categories</h2>
+
+			<ul>
+					<li class="cat-item cat-item-64203016"><a href="https://steveblank.com/category/2-minute-lessons/">2 Minute Lessons</a> (15)
+</li>
+	<li class="cat-item cat-item-2450"><a href="https://steveblank.com/category/air-force/">Air Force</a> (21)
+</li>
+	<li class="cat-item cat-item-1457175"><a href="https://steveblank.com/category/ardent/">Ardent</a> (9)
+</li>
+	<li class="cat-item cat-item-45014641"><a href="https://steveblank.com/category/business-model-versus-business-plan/">Business Model versus Business Plan</a> (64)
+</li>
+	<li class="cat-item cat-item-4787488"><a href="https://steveblank.com/category/california-coastal-commission/">California Coastal Commission</a> (9)
+</li>
+	<li class="cat-item cat-item-1470"><a href="https://steveblank.com/category/china/">China</a> (9)
+</li>
+	<li class="cat-item cat-item-6987201"><a href="https://steveblank.com/category/commencement-speeches/">Commencement Speeches</a> (9)
+</li>
+	<li class="cat-item cat-item-23993"><a href="https://steveblank.com/category/conservation/">Conservation</a> (4)
+</li>
+	<li class="cat-item cat-item-3075385"><a href="https://steveblank.com/category/convergent-technologies/">Convergent Technologies</a> (4)
+</li>
+	<li class="cat-item cat-item-635806586"><a href="https://steveblank.com/category/corporate-govt-innovation/">Corporate/Gov&#039;t Innovation</a> (133)
+</li>
+	<li class="cat-item cat-item-697702677"><a href="https://steveblank.com/category/covid-19-recovery/">Covid-19/Recovery</a> (10)
+</li>
+	<li class="cat-item cat-item-1874987"><a href="https://steveblank.com/category/customer-development/">Customer Development</a> (329)
+</li>
+	<li class="cat-item cat-item-25337102"><a href="https://steveblank.com/category/customer-development-manifesto/">Customer Development Manifesto</a> (34)
+</li>
+	<li class="cat-item cat-item-16840"><a href="https://steveblank.com/category/epiphany/">E.piphany</a> (13)
+</li>
+	<li class="cat-item cat-item-697967638"><a href="https://steveblank.com/category/educators-summit/">Educators Summit</a> (7)
+</li>
+	<li class="cat-item cat-item-697967634"><a href="https://steveblank.com/category/esl/">ESL</a> (8)
+</li>
+	<li class="cat-item cat-item-64567312"><a href="https://steveblank.com/category/familycareerculture/">Family/Career/Culture</a> (85)
+</li>
+	<li class="cat-item cat-item-697967641"><a href="https://steveblank.com/category/gordian-knot-center-for-national-security-innovation/">Gordian Knot Center for National Security Innovation</a> (14)
+</li>
+	<li class="cat-item cat-item-479441927"><a href="https://steveblank.com/category/hacking-for-defense/">Hacking For Defense</a> (44)
+</li>
+	<li class="cat-item cat-item-526158618"><a href="https://steveblank.com/category/hacking-for-diplomacy/">Hacking for Diplomacy</a> (10)
+</li>
+	<li class="cat-item cat-item-697967637"><a href="https://steveblank.com/category/hacking-for-recovery/">Hacking for Recovery</a> (5)
+</li>
+	<li class="cat-item cat-item-105397"><a href="https://steveblank.com/category/harvard-business-review/">Harvard Business Review</a> (12)
+</li>
+	<li class="cat-item cat-item-684268037"><a href="https://steveblank.com/category/innovation-doctrine/">Innovation Doctrine</a> (3)
+</li>
+	<li class="cat-item cat-item-340390495"><a href="https://steveblank.com/category/innovation-outposts/">Innovation Outposts</a> (4)
+</li>
+	<li class="cat-item cat-item-217160777"><a href="https://steveblank.com/category/investment-readiness-level/">Investment Readiness Level</a> (6)
+</li>
+	<li class="cat-item cat-item-53169179"><a href="https://steveblank.com/category/lean-launchpad/">Lean LaunchPad</a> (118)
+</li>
+	<li class="cat-item cat-item-261983049"><a href="https://steveblank.com/category/life-sciences-nih/">Life Sciences (NIH)</a> (26)
+</li>
+	<li class="cat-item cat-item-16879037"><a href="https://steveblank.com/category/market-types/">Market Types</a> (15)
+</li>
+	<li class="cat-item cat-item-175"><a href="https://steveblank.com/category/marketing/">Marketing</a> (28)
+</li>
+	<li class="cat-item cat-item-28276971"><a href="https://steveblank.com/category/mips-computers/">MIPS Computers</a> (2)
+</li>
+	<li class="cat-item cat-item-697967640"><a href="https://steveblank.com/category/national-security/">National Security</a> (49)
+</li>
+	<li class="cat-item cat-item-2064"><a href="https://steveblank.com/category/navy/">Navy</a> (8)
+</li>
+	<li class="cat-item cat-item-34826422"><a href="https://steveblank.com/category/nih-national-institutes-of-health/">NIH (National Institutes of Health)</a> (18)
+</li>
+	<li class="cat-item cat-item-16770755"><a href="https://steveblank.com/category/nsf-national-science-foundation/">NSF (National Science Foundation)</a> (19)
+</li>
+	<li class="cat-item cat-item-16848661"><a href="https://steveblank.com/category/rocket-science-games/">Rocket Science Games</a> (10)
+</li>
+	<li class="cat-item cat-item-137272104"><a href="https://steveblank.com/category/science-and-industrial-policy/">Science and Industrial Policy</a> (29)
+</li>
+	<li class="cat-item cat-item-16849552"><a href="https://steveblank.com/category/secret-history-of-silicon-valley/">Secret History of Silicon Valley</a> (26)
+</li>
+	<li class="cat-item cat-item-50184180"><a href="https://steveblank.com/category/siriusxm-radio-show/">SiriusXM Radio Show</a> (50)
+</li>
+	<li class="cat-item cat-item-235742"><a href="https://steveblank.com/category/supermac/">SuperMac</a> (12)
+</li>
+	<li class="cat-item cat-item-1591"><a href="https://steveblank.com/category/teaching/">Teaching</a> (180)
+</li>
+	<li class="cat-item cat-item-6"><a href="https://steveblank.com/category/technology/">Technology</a> (87)
+</li>
+	<li class="cat-item cat-item-697967636"><a href="https://steveblank.com/category/technology-innovation-and-modern-war/">Technology Innovation and Great Power Competition</a> (19)
+</li>
+	<li class="cat-item cat-item-697967642"><a href="https://steveblank.com/category/technology-innovation-and-modern-war-2/">Technology Innovation and Modern War</a> (23)
+</li>
+	<li class="cat-item cat-item-429989"><a href="https://steveblank.com/category/tesla/">Tesla</a> (5)
+</li>
+	<li class="cat-item cat-item-1"><a href="https://steveblank.com/category/uncategorized/">Uncategorized</a> (8)
+</li>
+	<li class="cat-item cat-item-202"><a href="https://steveblank.com/category/venture-capital/">Venture Capital</a> (86)
+</li>
+	<li class="cat-item cat-item-1087649"><a href="https://steveblank.com/category/vertical-markets/">Vertical Markets</a> (5)
+</li>
+	<li class="cat-item cat-item-715437"><a href="https://steveblank.com/category/zilog/">Zilog</a> (5)
+</li>
+			</ul>
+
+			</li>
+<li id="rss_links-3" class="widget widget_rss_links"><h2 class="widgettitle">Get Steve Blank via your RSS Feed</h2>
+<ul><li><a target="_self" href="https://steveblank.com/feed/" title="Subscribe to posts">RSS - Posts</a></li><li><a target="_self" href="https://steveblank.com/comments/feed/" title="Subscribe to comments">RSS - Comments</a></li></ul>
+</li>
+
+		<li id="recent-posts-2" class="widget widget_recent_entries">
+		<h2 class="widgettitle">Recent Posts</h2>
+
+		<ul>
+											<li>
+					<a href="https://steveblank.com/2026/04/09/nowhere-is-safe/" aria-current="page">Nowhere Is Safe</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2026/03/31/solving-yesterdays-problems-will-kill-you/">Solving Yesterday&#8217;s Problems Will Kill You</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2026/03/17/your-startup-is-probably-dead-on-arrival/">Your Startup Is Probably Dead On Arrival</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2026/02/24/time-to-move-on-the-reason-relationships-end/">Time to Move On &#8211; The Reason Relationships End</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2026/02/18/you-only-think-they-work-for-you/">You Only Think They Work For You</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2026/02/10/revisionist-history-aliens-secrets-and-conspiracies/">Revisionist History &#8211; Aliens, Secrets and Conspiracies</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2026/02/03/making-the-wrong-things-go-faster-at-the-department-of-war/">Making the Wrong Things Go Faster at The Department of War</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2025/12/16/the-department-of-war-directory/">The Department of War Directory</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2025/11/11/the-department-of-war-just-shot-the-accountants-and-opted-for-speed/">The Department of War Just Shot the Accountants and Opted for Speed</a>
+									</li>
+											<li>
+					<a href="https://steveblank.com/2025/10/30/it-only-took-20-years-but-the-strategic-management-society-now-believes-the-lean-startup-is-a-strategy-i-got-an-award-for-it/">It only took 20 years, but the Strategic Management Society now Believes the Lean Startup is a Strategy</a>
+									</li>
+					</ul>
+
+		</li>
+<li id="search-2" class="widget widget_search"><form method="get" id="searchform" action="https://steveblank.com/">
+<div>
+	<input type="text" value="" name="s" id="s" />
+	<input type="submit" id="searchsubmit" value="Search" />
+</div>
+</form></li>
+<li id="archives-2" class="widget widget_archive"><h2 class="widgettitle">Archives</h2>
+
+			<ul>
+					<li><a href='https://steveblank.com/2026/04/'>April 2026</a></li>
+	<li><a href='https://steveblank.com/2026/03/'>March 2026</a></li>
+	<li><a href='https://steveblank.com/2026/02/'>February 2026</a></li>
+	<li><a href='https://steveblank.com/2025/12/'>December 2025</a></li>
+	<li><a href='https://steveblank.com/2025/11/'>November 2025</a></li>
+	<li><a href='https://steveblank.com/2025/10/'>October 2025</a></li>
+	<li><a href='https://steveblank.com/2025/09/'>September 2025</a></li>
+	<li><a href='https://steveblank.com/2025/07/'>July 2025</a></li>
+	<li><a href='https://steveblank.com/2025/06/'>June 2025</a></li>
+	<li><a href='https://steveblank.com/2025/05/'>May 2025</a></li>
+	<li><a href='https://steveblank.com/2025/04/'>April 2025</a></li>
+	<li><a href='https://steveblank.com/2024/10/'>October 2024</a></li>
+	<li><a href='https://steveblank.com/2024/09/'>September 2024</a></li>
+	<li><a href='https://steveblank.com/2024/08/'>August 2024</a></li>
+	<li><a href='https://steveblank.com/2024/07/'>July 2024</a></li>
+	<li><a href='https://steveblank.com/2024/06/'>June 2024</a></li>
+	<li><a href='https://steveblank.com/2024/05/'>May 2024</a></li>
+	<li><a href='https://steveblank.com/2024/04/'>April 2024</a></li>
+	<li><a href='https://steveblank.com/2024/03/'>March 2024</a></li>
+	<li><a href='https://steveblank.com/2024/02/'>February 2024</a></li>
+	<li><a href='https://steveblank.com/2024/01/'>January 2024</a></li>
+	<li><a href='https://steveblank.com/2023/12/'>December 2023</a></li>
+	<li><a href='https://steveblank.com/2023/11/'>November 2023</a></li>
+	<li><a href='https://steveblank.com/2023/10/'>October 2023</a></li>
+	<li><a href='https://steveblank.com/2023/09/'>September 2023</a></li>
+	<li><a href='https://steveblank.com/2023/08/'>August 2023</a></li>
+	<li><a href='https://steveblank.com/2023/07/'>July 2023</a></li>
+	<li><a href='https://steveblank.com/2023/04/'>April 2023</a></li>
+	<li><a href='https://steveblank.com/2023/02/'>February 2023</a></li>
+	<li><a href='https://steveblank.com/2023/01/'>January 2023</a></li>
+	<li><a href='https://steveblank.com/2022/11/'>November 2022</a></li>
+	<li><a href='https://steveblank.com/2022/10/'>October 2022</a></li>
+	<li><a href='https://steveblank.com/2022/09/'>September 2022</a></li>
+	<li><a href='https://steveblank.com/2022/06/'>June 2022</a></li>
+	<li><a href='https://steveblank.com/2022/05/'>May 2022</a></li>
+	<li><a href='https://steveblank.com/2022/04/'>April 2022</a></li>
+	<li><a href='https://steveblank.com/2022/03/'>March 2022</a></li>
+	<li><a href='https://steveblank.com/2022/01/'>January 2022</a></li>
+	<li><a href='https://steveblank.com/2021/12/'>December 2021</a></li>
+	<li><a href='https://steveblank.com/2021/11/'>November 2021</a></li>
+	<li><a href='https://steveblank.com/2021/10/'>October 2021</a></li>
+	<li><a href='https://steveblank.com/2021/09/'>September 2021</a></li>
+	<li><a href='https://steveblank.com/2021/08/'>August 2021</a></li>
+	<li><a href='https://steveblank.com/2021/07/'>July 2021</a></li>
+	<li><a href='https://steveblank.com/2021/06/'>June 2021</a></li>
+	<li><a href='https://steveblank.com/2021/05/'>May 2021</a></li>
+	<li><a href='https://steveblank.com/2021/04/'>April 2021</a></li>
+	<li><a href='https://steveblank.com/2021/03/'>March 2021</a></li>
+	<li><a href='https://steveblank.com/2021/02/'>February 2021</a></li>
+	<li><a href='https://steveblank.com/2021/01/'>January 2021</a></li>
+	<li><a href='https://steveblank.com/2020/12/'>December 2020</a></li>
+	<li><a href='https://steveblank.com/2020/11/'>November 2020</a></li>
+	<li><a href='https://steveblank.com/2020/10/'>October 2020</a></li>
+	<li><a href='https://steveblank.com/2020/09/'>September 2020</a></li>
+	<li><a href='https://steveblank.com/2020/08/'>August 2020</a></li>
+	<li><a href='https://steveblank.com/2020/07/'>July 2020</a></li>
+	<li><a href='https://steveblank.com/2020/06/'>June 2020</a></li>
+	<li><a href='https://steveblank.com/2020/05/'>May 2020</a></li>
+	<li><a href='https://steveblank.com/2020/04/'>April 2020</a></li>
+	<li><a href='https://steveblank.com/2020/03/'>March 2020</a></li>
+	<li><a href='https://steveblank.com/2020/02/'>February 2020</a></li>
+	<li><a href='https://steveblank.com/2020/01/'>January 2020</a></li>
+	<li><a href='https://steveblank.com/2019/12/'>December 2019</a></li>
+	<li><a href='https://steveblank.com/2019/11/'>November 2019</a></li>
+	<li><a href='https://steveblank.com/2019/10/'>October 2019</a></li>
+	<li><a href='https://steveblank.com/2019/09/'>September 2019</a></li>
+	<li><a href='https://steveblank.com/2019/06/'>June 2019</a></li>
+	<li><a href='https://steveblank.com/2019/05/'>May 2019</a></li>
+	<li><a href='https://steveblank.com/2019/04/'>April 2019</a></li>
+	<li><a href='https://steveblank.com/2019/03/'>March 2019</a></li>
+	<li><a href='https://steveblank.com/2019/01/'>January 2019</a></li>
+	<li><a href='https://steveblank.com/2018/12/'>December 2018</a></li>
+	<li><a href='https://steveblank.com/2018/11/'>November 2018</a></li>
+	<li><a href='https://steveblank.com/2018/10/'>October 2018</a></li>
+	<li><a href='https://steveblank.com/2018/09/'>September 2018</a></li>
+	<li><a href='https://steveblank.com/2018/08/'>August 2018</a></li>
+	<li><a href='https://steveblank.com/2018/07/'>July 2018</a></li>
+	<li><a href='https://steveblank.com/2018/06/'>June 2018</a></li>
+	<li><a href='https://steveblank.com/2018/04/'>April 2018</a></li>
+	<li><a href='https://steveblank.com/2018/03/'>March 2018</a></li>
+	<li><a href='https://steveblank.com/2018/02/'>February 2018</a></li>
+	<li><a href='https://steveblank.com/2018/01/'>January 2018</a></li>
+	<li><a href='https://steveblank.com/2017/11/'>November 2017</a></li>
+	<li><a href='https://steveblank.com/2017/10/'>October 2017</a></li>
+	<li><a href='https://steveblank.com/2017/09/'>September 2017</a></li>
+	<li><a href='https://steveblank.com/2017/08/'>August 2017</a></li>
+	<li><a href='https://steveblank.com/2017/07/'>July 2017</a></li>
+	<li><a href='https://steveblank.com/2017/06/'>June 2017</a></li>
+	<li><a href='https://steveblank.com/2017/05/'>May 2017</a></li>
+	<li><a href='https://steveblank.com/2017/04/'>April 2017</a></li>
+	<li><a href='https://steveblank.com/2017/03/'>March 2017</a></li>
+	<li><a href='https://steveblank.com/2017/02/'>February 2017</a></li>
+	<li><a href='https://steveblank.com/2017/01/'>January 2017</a></li>
+	<li><a href='https://steveblank.com/2016/12/'>December 2016</a></li>
+	<li><a href='https://steveblank.com/2016/11/'>November 2016</a></li>
+	<li><a href='https://steveblank.com/2016/10/'>October 2016</a></li>
+	<li><a href='https://steveblank.com/2016/09/'>September 2016</a></li>
+	<li><a href='https://steveblank.com/2016/08/'>August 2016</a></li>
+	<li><a href='https://steveblank.com/2016/07/'>July 2016</a></li>
+	<li><a href='https://steveblank.com/2016/06/'>June 2016</a></li>
+	<li><a href='https://steveblank.com/2016/05/'>May 2016</a></li>
+	<li><a href='https://steveblank.com/2016/04/'>April 2016</a></li>
+	<li><a href='https://steveblank.com/2016/03/'>March 2016</a></li>
+	<li><a href='https://steveblank.com/2016/02/'>February 2016</a></li>
+	<li><a href='https://steveblank.com/2016/01/'>January 2016</a></li>
+	<li><a href='https://steveblank.com/2015/12/'>December 2015</a></li>
+	<li><a href='https://steveblank.com/2015/11/'>November 2015</a></li>
+	<li><a href='https://steveblank.com/2015/10/'>October 2015</a></li>
+	<li><a href='https://steveblank.com/2015/09/'>September 2015</a></li>
+	<li><a href='https://steveblank.com/2015/08/'>August 2015</a></li>
+	<li><a href='https://steveblank.com/2015/07/'>July 2015</a></li>
+	<li><a href='https://steveblank.com/2015/06/'>June 2015</a></li>
+	<li><a href='https://steveblank.com/2015/05/'>May 2015</a></li>
+	<li><a href='https://steveblank.com/2015/03/'>March 2015</a></li>
+	<li><a href='https://steveblank.com/2015/02/'>February 2015</a></li>
+	<li><a href='https://steveblank.com/2015/01/'>January 2015</a></li>
+	<li><a href='https://steveblank.com/2014/12/'>December 2014</a></li>
+	<li><a href='https://steveblank.com/2014/11/'>November 2014</a></li>
+	<li><a href='https://steveblank.com/2014/10/'>October 2014</a></li>
+	<li><a href='https://steveblank.com/2014/09/'>September 2014</a></li>
+	<li><a href='https://steveblank.com/2014/08/'>August 2014</a></li>
+	<li><a href='https://steveblank.com/2014/07/'>July 2014</a></li>
+	<li><a href='https://steveblank.com/2014/06/'>June 2014</a></li>
+	<li><a href='https://steveblank.com/2014/05/'>May 2014</a></li>
+	<li><a href='https://steveblank.com/2014/04/'>April 2014</a></li>
+	<li><a href='https://steveblank.com/2014/03/'>March 2014</a></li>
+	<li><a href='https://steveblank.com/2014/02/'>February 2014</a></li>
+	<li><a href='https://steveblank.com/2014/01/'>January 2014</a></li>
+	<li><a href='https://steveblank.com/2013/12/'>December 2013</a></li>
+	<li><a href='https://steveblank.com/2013/11/'>November 2013</a></li>
+	<li><a href='https://steveblank.com/2013/10/'>October 2013</a></li>
+	<li><a href='https://steveblank.com/2013/09/'>September 2013</a></li>
+	<li><a href='https://steveblank.com/2013/08/'>August 2013</a></li>
+	<li><a href='https://steveblank.com/2013/07/'>July 2013</a></li>
+	<li><a href='https://steveblank.com/2013/06/'>June 2013</a></li>
+	<li><a href='https://steveblank.com/2013/05/'>May 2013</a></li>
+	<li><a href='https://steveblank.com/2013/04/'>April 2013</a></li>
+	<li><a href='https://steveblank.com/2013/03/'>March 2013</a></li>
+	<li><a href='https://steveblank.com/2013/02/'>February 2013</a></li>
+	<li><a href='https://steveblank.com/2013/01/'>January 2013</a></li>
+	<li><a href='https://steveblank.com/2012/12/'>December 2012</a></li>
+	<li><a href='https://steveblank.com/2012/11/'>November 2012</a></li>
+	<li><a href='https://steveblank.com/2012/10/'>October 2012</a></li>
+	<li><a href='https://steveblank.com/2012/09/'>September 2012</a></li>
+	<li><a href='https://steveblank.com/2012/08/'>August 2012</a></li>
+	<li><a href='https://steveblank.com/2012/07/'>July 2012</a></li>
+	<li><a href='https://steveblank.com/2012/06/'>June 2012</a></li>
+	<li><a href='https://steveblank.com/2012/05/'>May 2012</a></li>
+	<li><a href='https://steveblank.com/2012/04/'>April 2012</a></li>
+	<li><a href='https://steveblank.com/2012/03/'>March 2012</a></li>
+	<li><a href='https://steveblank.com/2012/02/'>February 2012</a></li>
+	<li><a href='https://steveblank.com/2012/01/'>January 2012</a></li>
+	<li><a href='https://steveblank.com/2011/12/'>December 2011</a></li>
+	<li><a href='https://steveblank.com/2011/11/'>November 2011</a></li>
+	<li><a href='https://steveblank.com/2011/10/'>October 2011</a></li>
+	<li><a href='https://steveblank.com/2011/09/'>September 2011</a></li>
+	<li><a href='https://steveblank.com/2011/08/'>August 2011</a></li>
+	<li><a href='https://steveblank.com/2011/07/'>July 2011</a></li>
+	<li><a href='https://steveblank.com/2011/06/'>June 2011</a></li>
+	<li><a href='https://steveblank.com/2011/05/'>May 2011</a></li>
+	<li><a href='https://steveblank.com/2011/04/'>April 2011</a></li>
+	<li><a href='https://steveblank.com/2011/03/'>March 2011</a></li>
+	<li><a href='https://steveblank.com/2011/02/'>February 2011</a></li>
+	<li><a href='https://steveblank.com/2011/01/'>January 2011</a></li>
+	<li><a href='https://steveblank.com/2010/12/'>December 2010</a></li>
+	<li><a href='https://steveblank.com/2010/11/'>November 2010</a></li>
+	<li><a href='https://steveblank.com/2010/10/'>October 2010</a></li>
+	<li><a href='https://steveblank.com/2010/09/'>September 2010</a></li>
+	<li><a href='https://steveblank.com/2010/08/'>August 2010</a></li>
+	<li><a href='https://steveblank.com/2010/07/'>July 2010</a></li>
+	<li><a href='https://steveblank.com/2010/06/'>June 2010</a></li>
+	<li><a href='https://steveblank.com/2010/05/'>May 2010</a></li>
+	<li><a href='https://steveblank.com/2010/04/'>April 2010</a></li>
+	<li><a href='https://steveblank.com/2010/03/'>March 2010</a></li>
+	<li><a href='https://steveblank.com/2010/02/'>February 2010</a></li>
+	<li><a href='https://steveblank.com/2010/01/'>January 2010</a></li>
+	<li><a href='https://steveblank.com/2009/12/'>December 2009</a></li>
+	<li><a href='https://steveblank.com/2009/11/'>November 2009</a></li>
+	<li><a href='https://steveblank.com/2009/10/'>October 2009</a></li>
+	<li><a href='https://steveblank.com/2009/09/'>September 2009</a></li>
+	<li><a href='https://steveblank.com/2009/08/'>August 2009</a></li>
+	<li><a href='https://steveblank.com/2009/07/'>July 2009</a></li>
+	<li><a href='https://steveblank.com/2009/06/'>June 2009</a></li>
+	<li><a href='https://steveblank.com/2009/05/'>May 2009</a></li>
+	<li><a href='https://steveblank.com/2009/04/'>April 2009</a></li>
+	<li><a href='https://steveblank.com/2009/03/'>March 2009</a></li>
+	<li><a href='https://steveblank.com/2009/02/'>February 2009</a></li>
+			</ul>
+
+			</li>
+<li id="pages-2" class="widget widget_pages"><h2 class="widgettitle">Other Stuff</h2>
+
+			<ul>
+				<li class="page_item page-item-2"><a href="https://steveblank.com/about/">About Steve</a></li>
+<li class="page_item page-item-22"><a href="https://steveblank.com/tools-and-blogs-for-entrepreneurs/">Startup Tools</a></li>
+<li class="page_item page-item-62"><a href="https://steveblank.com/secret-history/">Secret History</a></li>
+<li class="page_item page-item-68"><a href="https://steveblank.com/books-for-startups/">Books for Startups</a></li>
+<li class="page_item page-item-11025"><a href="https://steveblank.com/slides/">Slides/Videos</a></li>
+<li class="page_item page-item-25609"><a href="https://steveblank.com/raising-money/">Raising Money</a></li>
+			</ul>
+
+			</li>
+
+</ul>
+	</div>
+
+<!-- End Obar -->
+	<div class="wrapper"><!-- This wrapper class appears only on Page and Single Post pages. -->
+	<div class="narrowcolumnwrapper"><div class="narrowcolumn">
+
+		<div class="content">
+
+			
+			<div class="post-33737 post type-post status-publish format-standard hentry category-national-security category-technology-innovation-and-modern-war-2" id="post-33737">
+
+				<h2><a href="https://steveblank.com/2026/04/09/nowhere-is-safe/" rel="bookmark" title="Nowhere Is Safe">Nowhere Is Safe</a></h2>
+
+				<div class="postinfo">
+					Posted on <span class="postdate">April 9, 2026</span> by steve blank									</div>
+
+				<div class="entry">
+
+					<p><span style="font-weight: 400;">Drones in Ukraine and in the War with Iran have made the surface of the earth a contested space. The U.S. has discovered that 1) air superiority and missile defense systems (</span><a href="https://www.congress.gov/crs-product/IF12645" target="_blank" rel="noopener"><span style="font-weight: 400;">THAAD</span></a><span style="font-weight: 400;">, </span><a href="https://en.wikipedia.org/wiki/MIM-104_Patriot" target="_blank" rel="noopener"><span style="font-weight: 400;">Patriot</span></a><span style="font-weight: 400;"> batteries) designed to counter tens or hundreds of aircraft and missiles is insufficient against asymmetric attacks of thousands of drones. And that 2) undefended high value </span><i><span style="font-weight: 400;">fixed </span></i><span style="font-weight: 400;">civilian infrastructure &#8211; oil tankers, data centers, desalination plants, oil refineries, energy nodes, factories, et al -are all at risk. </span></p>
+<p><span style="font-weight: 400;">When the targets are no longer just military assets but </span><i><span style="font-weight: 400;">anything</span></i><span style="font-weight: 400;"> valuable on the surface, the long term math no longer favors the defender. To solve this problem the U.S. is spending $10s of billions of dollars on low-cost Counter-UAS systems &#8211; detection systems, inexpensive missiles, kamikaze drones, microwave and laser weapons.</span></p>
+<p><span style="font-weight: 400;">But what we’re not spending $10s of billions on is learning how to cheaply and quickly put our high-value, hard-to-replace, and time-critical assets (munitions, fuel distribution, Command and Control continuity nodes, spares), etc., out of harm&#8217;s way &#8211; sheltered, underground (or in space). </span></p>
+<p><span style="font-weight: 400;">The lessons from Gaza reinforce that underground systems can also preserve forces and enable maneuver. The lessons from Ukraine are that survivability while under constant drone observation/attack requires using underground facilities to provide overhead cover (while masking RF, infrared and other signatures). </span><span style="font-weight: 400;">And the lessons from Iran’s attacks on infrastructure in the </span><a href="https://en.wikipedia.org/wiki/Gulf_Cooperation_Council"><span style="font-weight: 400;">Gulf Cooperation Council</span></a><span style="font-weight: 400;"> countries is that </span><i><span style="font-weight: 400;">anything</span></i><span style="font-weight: 400;"> on the surface is going to be a target.</span></p>
+<p><span style="font-weight: 400;">We need to rethink the nature of force protection as well as military and civilian infrastructure protection.</span></p>
+<hr />
+<div style="background: #eeeeee; border: 2px solid black; padding: 16px 18px; margin: 20px 0; border-radius: 2px;"><b>Air Defense Systems</b><b><br />
+</b><span style="font-weight: 400;">For decades the U.S. has built air defense systems designed for shooting down aircraft and missiles.</span><span style="font-weight: 400;">The Navy’s</span><a href="https://www.youtube.com/watch?v=O8uk2mZ-Gv0" target="_blank" rel="noopener"><span style="font-weight: 400;"> Aegis destroyers</span></a><span style="font-weight: 400;"> provide defense for carrier strike groups using surface-to-air missiles against hostile aircraft and missiles. The Army’s </span><a href="https://en.wikipedia.org/wiki/MIM-104_Patriot"><span style="font-weight: 400;">Patriot</span></a><span style="font-weight: 400;"> anti-aircraft batteries provide area protection against aircraft and missiles. The </span><a href="https://www.mda.mil/" target="_blank" rel="noopener"><span style="font-weight: 400;">Missile Defense Agency</span></a><span style="font-weight: 400;"> (MDA) provides missile defense from North Korea for Guam and a limited missile defense for the U.S.  <a href="https://www.mda.mil/" target="_blank" rel="noopener">MDA</a> is leading the development of </span><a href="https://en.wikipedia.org/wiki/Golden_Dome_(missile_defense_system)" target="_blank" rel="noopener"><span style="font-weight: 400;">Golden Dome</span></a><span style="font-weight: 400;"><span style="font-weight: 400;">, a missile defense system to protect the entire U.S. against ballistic, cruise, and hypersonic missiles from China and Russia. </span></span><span style="font-weight: 400;"><span style="font-weight: 400;">All of these systems were designed to use expensive missiles to shoot down equally expensive aircraft and missiles. None of these systems were designed to shoot down hundreds/thousands of very low-cost drones.</span></span></div>
+<div style="background: #eeeeee; border: 2px solid black; padding: 16px 18px; margin: 20px 0; border-radius: 2px;">
+<p><i><span style="font-weight: 400;">Aircraft Protection</span></i><br />
+<span style="font-weight: 400;">After destroying Iraqi aircraft shelters in the Gulf War with 2,000-lb bombs, the U.S. Air Force convinced itself that building aircraft and maintenance shelters was not worth the investment. Instead, their plan &#8211; the </span><a href="https://ndupress.ndu.edu/Media/News/News-Article-View/Article/4157349/protecting-ace-air-defense-and-agile-combat-employment/" target="_blank" rel="noopener"><span style="font-weight: 400;">Agile Combat Employment (ACE) program</span></a><span style="font-weight: 400;"> &#8211; was to disperse small teams to remote austere locations (with minimal air defense systems) in time of war. Dispersal along with air superiority would substitute for building hardened shelters. <em>Oops</em>. It didn&#8217;t count on low-cost drones finding those dispersed aircraft. (One would have thought that Ukraine’s </span><a href="https://www.youtube.com/shorts/eCmmKz9A3Lc" target="_blank" rel="noopener"><span style="font-weight: 400;">Operation Spider’s Web</span></a><span style="font-weight: 400;"><span style="font-weight: 400;"> using 117 drones smuggled in shipping containers &#8211; which struck and destroyed Russian bombers &#8211; would have been a wakeup call.)</span></span></p>
+<p><span style="font-weight: 400;">The cost of not having hardened aircraft shelters during the 2026 Iran War came home when Iran destroyed an AWACS aircraft and KC-135 tankers sitting in the open. Meanwhile, China, Iran and North Korea have made massive investments in hardened shelters and underground facilities.</span></p>
+</div>
+<p><b>Protecting Ground Forces<br />
+</b><span style="font-weight: 400;">The problem of protecting troops with foxholes against artillery is hundreds of years old. In WWI, trenches connected foxholes into systems. Bunkers were hardened against direct hits. Each step was a response to increased lethality from above. Today, drones are the new artillery; a persistent, cheap and precise overhead threat but with the ability to maneuver laterally, enter openings, and loiter. And mass drone attacks put every high value military </span><i><span style="font-weight: 400;">and</span></i><span style="font-weight: 400;"> civilian target on the surface at risk. Fielding more hardened shelters for soldiers like the </span><a href="https://www.twz.com/news-features/growing-drone-threats-lead-to-army-modular-shelter-kit-improvements" target="_blank" rel="noopener"><span style="font-weight: 400;">Army&#8217;s Modular Protective System Overhead Cover</span></a><span style="font-weight: 400;"> shelters is a first step for FPV kamikaze drones defense, but drones can get inside buildings through any sufficiently sized openings. </span></p>
+<p><b>Drone Protection<br />
+</b><span style="font-weight: 400;">Ukraine has installed <a href="https://x.com/DVKirichenko/status/2033321222323454155" target="_blank" rel="noopener">~500 miles of anti-drone net tunnels</a> with a goal of <a href="https://www.reuters.com/business/aerospace-defense/ukraine-cover-4000-km-roads-with-anti-drone-nets-by-year-end-minister-says-2026-02-25/#:~:text=Reuters%20Plus-,Ukraine%20to%20cover%204%2C000%20km%20of%20roads%20with%20anti%2Ddrone,with%20the%20remotely%20piloted%20aircraft." target="_blank" rel="noopener">2,500 miles by the end of 2026</a>. These are metal poles and fishing nets stretched over roads but they represent the same instinct: the surface is a kill zone, so cover it. Russia has done the same.</span></p>
+<p><img data-recalc-dims="1" fetchpriority="high" decoding="async" data-attachment-id="33773" data-permalink="https://steveblank.com/2026/04/09/nowhere-is-safe/ukraine-anti-drone-netting/" data-orig-file="https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?fit=2816%2C1536&amp;ssl=1" data-orig-size="2816,1536" data-comments-opened="1" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}" data-image-title="Ukraine anti drone netting" data-image-description="" data-image-caption="" data-large-file="https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?fit=468%2C255&amp;ssl=1" class="aligncenter size-full wp-image-33773" src="https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?resize=468%2C255&#038;ssl=1" alt="" width="468" height="255" srcset="https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?w=2816&amp;ssl=1 2816w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?resize=300%2C164&amp;ssl=1 300w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?resize=1024%2C559&amp;ssl=1 1024w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?resize=150%2C82&amp;ssl=1 150w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?resize=768%2C419&amp;ssl=1 768w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?resize=1536%2C838&amp;ssl=1 1536w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?resize=2048%2C1117&amp;ssl=1 2048w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?w=936&amp;ssl=1 936w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/Ukraine-anti-drone-netting.jpg?w=1404&amp;ssl=1 1404w" sizes="(max-width: 468px) 100vw, 468px" /></p>
+<p><span style="font-weight: 400;">The logical response is to go underground (or out to space) but the technology to do it quickly, cheaply, and at scale is genuinely new. The gap in current thinking is between &#8220;put up nets&#8221; (cheap, fast, limited) and &#8220;build a Cold War concrete bunker&#8221; (expensive, slow, permanent). What&#8217;s missing is the middle layer &#8211; </span><i><span style="font-weight: 400;">rapidly bored shallow tunnels</span></i><span style="font-weight: 400;"> that provide genuine overhead cover for movement corridors, equipment parking, and personnel protection. </span></p>
+<p><b>What tunnels solve that nets and shelters don&#8217;t</b><span style="font-weight: 400;"><br />
+</span><span style="font-weight: 400;">A net stops an FPV drone&#8217;s propellers. A shelter stops shrapnel. But a tunnel 15-30 feet underground is invisible to ISR, immune most to top-attack munitions, can&#8217;t be entered by a drone through a door or window, and survives anything short of a bunker-buster. Gaza proved that even with total air superiority and ground control, Israel has destroyed only about <a href="https://www.jpost.com/israel-news/article-871557#google_vignette" target="_blank" rel="noopener">40 percent</a> of Gaza&#8217;s tunnels after two and a half years of war.</span></p>
+<p><span style="font-weight: 400;">That&#8217;s an asymmetric defender&#8217;s advantage the U.S. military should be thinking about for its own use, not just as a threat to overcome.</span></p>
+<p><span style="font-weight: 400;">What&#8217;s changed to make this feasible is that we may not need boring tunnels per se, but instead modular, pre-fabricated tunnel segments that can be installed with cut-and-cover methods at expeditionary bases. Or autonomous boring machines sized for military logistics (smaller versions of <a href="https://www.boringcompany.com/" target="_blank" rel="noopener">the Boring Company</a> <a href="https://www.boringcompany.com/prufrock" target="_blank" rel="noopener">TBMs</a>) corridors rather than highway traffic.</span></p>
+<p><img data-recalc-dims="1" decoding="async" data-attachment-id="33752" data-permalink="https://steveblank.com/2026/04/09/nowhere-is-safe/army-boring-machine-front/" data-orig-file="https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?fit=2816%2C1536&amp;ssl=1" data-orig-size="2816,1536" data-comments-opened="1" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}" data-image-title="army boring machine front" data-image-description="" data-image-caption="" data-large-file="https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?fit=468%2C255&amp;ssl=1" class="aligncenter size-full wp-image-33752" src="https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?resize=468%2C255&#038;ssl=1" alt="" width="468" height="255" srcset="https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?w=2816&amp;ssl=1 2816w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?resize=300%2C164&amp;ssl=1 300w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?resize=1024%2C559&amp;ssl=1 1024w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?resize=150%2C82&amp;ssl=1 150w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?resize=768%2C419&amp;ssl=1 768w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?resize=1536%2C838&amp;ssl=1 1536w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?resize=2048%2C1117&amp;ssl=1 2048w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?w=936&amp;ssl=1 936w, https://i0.wp.com/steveblank.com/wp-content/uploads/2026/04/army-boring-machine-front.jpg?w=1404&amp;ssl=1 1404w" sizes="(max-width: 468px) 100vw, 468px" /></p>
+<p><b>The problem is a lack of urgency and imagination<br />
+</b><span style="font-weight: 400;">The problem is real, the incumbents (<a href="https://www.usace.army.mil/" target="_blank" rel="noopener">Army Corps of Engineers</a>) are slow, and the existing commercial tunneling industry isn&#8217;t thinking about expeditionary military applications.</span></p>
+<p><span style="font-weight: 400;">The doctrinal gap is between &#8220;dig a foxhole with an entrenching tool&#8221; (individual soldier, hours) or deploy a few </span><a href="https://www.twz.com/news-features/growing-drone-threats-lead-to-army-modular-shelter-kit-improvements"><span style="font-weight: 400;">Army&#8217;s Modular Protective System Overhead Cover</span></a><span style="font-weight: 400;"> shelters or &#8220;build a Cold War hardened aircraft shelter&#8221; (major construction project, years, billions). There&#8217;s no doctrine for rapidly boring hardened underground movement corridors, dispersed equipment shelters, or protected command post positions using modern tunneling technology.</span></p>
+<p><span style="font-weight: 400;">Army doctrine treats excavation as something done with organic engineer equipment — backhoes, bulldozers, troops with shovels — to create individual fighting positions and cut-and-cover bunkers. The Air Force doctrine barely addresses physical hardening at all, having spent 30 years assuming air superiority would substitute for it.</span></p>
+<p><span style="font-weight: 400;">Nobody in the doctrinal community is asking: what if the Army could cut and cover 100 meters of precast tunnel segments in a day or if we could bore a 12-foot diameter tunnel 30 feet underground at a rate of a hundred of meters per week and use it as a protected logistics corridor, command post, or aircraft revetment?</span></p>
+<p><b>Summary<br />
+</b>Oceans on both sides and friendly nations on our borders have lulled America into a false sense of security. After all, the U.S. has not fought a foreign force on American soil since 1812.</p>
+<p><span style="font-weight: 400;">Protection and survivability is no longer a problem for a single service nor is it a problem of a single solution or an incremental solution. Something fundamentally disruptive has changed in the nature of asymmetric warfare and there’s no going back. While we’re actively chasing immediate solutions (<a href="https://en.wikipedia.org/wiki/Golden_Dome_(missile_defense_system)" target="_blank" rel="noopener">Golden Dome</a>, <a href="https://media.defense.gov/2025/Aug/28/2003790021/-1/-1/0/ESTABLISHMENT-OF-JOINT-INTERAGENCY-TASK-FORCE-401.PDF" target="_blank" rel="noopener">JTAF-401</a>, et al), we need to rethink the nature of force protection, and military and civilian infrastructure protection. Protection and survivability solutions are not as sexy as buying aircraft or weapons systems but they may be the key to winning a war.</span></p>
+<p><span style="font-weight: 400;">The U.S. needs a coherent protection and survivability strategy across the DoW and all sectors of our economy. This conversation needs to be not only about how we do it, but </span><i><span style="font-weight: 400;">how we organize</span></i><span style="font-weight: 400;"> to do it, how we </span><i><span style="font-weight: 400;">budget and pay for it</span></i><span style="font-weight: 400;"> and how we </span><i><span style="font-weight: 400;">rapidly deploy</span></i><span style="font-weight: 400;"> it.</span></p>
+<p><b>Lessons Learned</b></p>
+<blockquote>
+<ul>
+<li style="font-weight: 400;" aria-level="1"><span style="font-weight: 400;">There is no coherent protection and survivability strategy that addresses drones across the DoW and the whole of nation</span>
+<ul>
+<li style="font-weight: 400;" aria-level="2"><span style="font-weight: 400;">Just point solutions</span></li>
+</ul>
+</li>
+<li><span style="font-weight: 400;">For troops near the front, tunnels could reduce visual, thermal, and RF signature while providing fragment protection with a network of small, concealed, overhead- covered positions, short connectors, buried command posts, protected aid stations, and revetted vehicle hides.  </span></li>
+<li><span style="font-weight: 400;">We need to underground assets that cannot be quickly replaced </span>
+<ul>
+<li><span style="font-weight: 400;">Command posts, comms nodes, ammunition, fuel distribution points, repair facilities, key power systems, maintenance spares, and high-value aircraft or drones.  </span></li>
+<li><span style="font-weight: 400;">Think protected taxiways, blast walls, covered trenches, buried cabling, alternate exits, redundant portals, and rapid runway repair. Sortie generation under attack depends on a whole system, not one bunker.  </span></li>
+</ul>
+</li>
+<li><span style="font-weight: 400;">We need to work with commercial companies to harden/defend their sites</span>
+<ul>
+<li><span style="font-weight: 400;">Provide active defenses and incentives for under-grounding critical facilities</span></li>
+</ul>
+</li>
+<li style="font-weight: 400;" aria-level="1"><span style="font-weight: 400;">The Army and Air Force need to rethink their doctrines and techniques for Protection and Survivability</span>
+<ul>
+<li style="font-weight: 400;" aria-level="2"><span style="font-weight: 400;">Army Techniques Publications (ATP) 3-37.34 &#8211; Survivability Operations treat excavation as something done with backhoes, bulldozers, troops with shovels to create individual fighting positions and cut-and-cover bunkers. Update it.</span></li>
+<li style="font-weight: 400;" aria-level="2"><span style="font-weight: 400;">The Air Force needs to do the same with AFDP 3-10, AFDP 3-0.1 (Force Protection and </span><a href="https://www.wbdg.org/FFC/AF/AFTTP/afttp_3_32.34_v3.pdf"><span style="font-weight: 400;">AFTTP 3-32.34v3</span></a><span style="font-weight: 400;">, AFH 10-222, Volume 14 and UFC 3-340-02</span></li>
+</ul>
+</li>
+<li>We need to think of force and infrastructure protection not piecemeal but holistically</li>
+<li>
+<ul>
+<li><span style="font-weight: 400;">Part of any weapons systems requirement and budget should now include protection and survivability </span></li>
+<li><span style="font-weight: 400;">Protection and survivability should be deployed concurrently with weapons systems</span></li>
+</ul>
+</li>
+<li style="font-weight: 400;" aria-level="2"><span style="font-weight: 400;">We need a Whole of Nation approach to protection and survivability for both the force and critical infrastructure</span></li>
+</ul>
+</blockquote>
+<iframe width="100%" height="91" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F2300361251&width=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false"></iframe>
+<div class="sharedaddy sd-sharing-enabled"><div class="robots-nocontent sd-block sd-social sd-social-official sd-sharing"><h3 class="sd-title">Share this:</h3><div class="sd-content"><ul><li class="share-print"><a rel="nofollow noopener noreferrer"
+				data-shared="sharing-print-33737"
+				class="share-print sd-button"
+				href="https://steveblank.com/2026/04/09/nowhere-is-safe/#print?share=print"
+				target="_blank"
+				aria-labelledby="sharing-print-33737"
+				>
+				<span id="sharing-print-33737" hidden>Print (Opens in new window)</span>
+				<span>Print</span>
+			</a></li><li class="share-email"><a rel="nofollow noopener noreferrer"
+				data-shared="sharing-email-33737"
+				class="share-email sd-button"
+				href="mailto:?subject=%5BShared%20Post%5D%20Nowhere%20Is%20Safe&#038;body=https%3A%2F%2Fsteveblank.com%2F2026%2F04%2F09%2Fnowhere-is-safe%2F&#038;share=email"
+				target="_blank"
+				aria-labelledby="sharing-email-33737"
+				data-email-share-error-title="Do you have email set up?" data-email-share-error-text="If you&#039;re having problems sharing via email, you might not have email set up for your browser. You may need to create a new email yourself." data-email-share-nonce="09dc9c4ecd" data-email-share-track-url="https://steveblank.com/2026/04/09/nowhere-is-safe/?share=email">
+				<span id="sharing-email-33737" hidden>Email a link to a friend (Opens in new window)</span>
+				<span>Email</span>
+			</a></li><li class="share-facebook"><div class="fb-share-button" data-href="https://steveblank.com/2026/04/09/nowhere-is-safe/" data-layout="button_count"></div></li><li class="share-twitter"><a href="https://twitter.com/share" class="twitter-share-button" data-url="https://steveblank.com/2026/04/09/nowhere-is-safe/" data-text="Nowhere Is Safe"  >Tweet</a></li><li class="share-linkedin"><div class="linkedin_button"><script type="in/share" data-url="https://steveblank.com/2026/04/09/nowhere-is-safe/" data-counter="right"></script></div></li><li class="share-reddit"><a rel="nofollow noopener noreferrer"
+				data-shared="sharing-reddit-33737"
+				class="share-reddit sd-button"
+				href="https://steveblank.com/2026/04/09/nowhere-is-safe/?share=reddit"
+				target="_blank"
+				aria-labelledby="sharing-reddit-33737"
+				>
+				<span id="sharing-reddit-33737" hidden>Share on Reddit (Opens in new window)</span>
+				<span>Reddit</span>
+			</a></li><li class="share-jetpack-whatsapp"><a rel="nofollow noopener noreferrer"
+				data-shared="sharing-whatsapp-33737"
+				class="share-jetpack-whatsapp sd-button"
+				href="https://steveblank.com/2026/04/09/nowhere-is-safe/?share=jetpack-whatsapp"
+				target="_blank"
+				aria-labelledby="sharing-whatsapp-33737"
+				>
+				<span id="sharing-whatsapp-33737" hidden>Share on WhatsApp (Opens in new window)</span>
+				<span>WhatsApp</span>
+			</a></li><li class="share-pinterest"><div class="pinterest_button"><a href="https://www.pinterest.com/pin/create/button/?url=https%3A%2F%2Fsteveblank.com%2F2026%2F04%2F09%2Fnowhere-is-safe%2F&#038;media=https%3A%2F%2Fsteveblank.com%2Fwp-content%2Fuploads%2F2026%2F04%2FUkraine-anti-drone-netting.jpg&#038;description=Nowhere%20Is%20Safe" data-pin-do="buttonPin" data-pin-config="beside"><img data-recalc-dims="1" src="https://i0.wp.com/assets.pinterest.com/images/pidgets/pinit_fg_en_rect_gray_20.png?w=468" /></a></div></li><li class="share-telegram"><a rel="nofollow noopener noreferrer"
+				data-shared="sharing-telegram-33737"
+				class="share-telegram sd-button"
+				href="https://steveblank.com/2026/04/09/nowhere-is-safe/?share=telegram"
+				target="_blank"
+				aria-labelledby="sharing-telegram-33737"
+				>
+				<span id="sharing-telegram-33737" hidden>Share on Telegram (Opens in new window)</span>
+				<span>Telegram</span>
+			</a></li><li class="share-tumblr"><a class="tumblr-share-button" target="_blank" href="https://www.tumblr.com/share" data-title="Nowhere Is Safe" data-content="https://steveblank.com/2026/04/09/nowhere-is-safe/" title="Share on Tumblr">Share on Tumblr</a></li><li class="share-end"></li></ul></div></div></div><div class='sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded' id='like-post-wrapper-6599589-33737-69dba887ba35f' data-src='https://widgets.wp.com/likes/?ver=15.7#blog_id=6599589&amp;post_id=33737&amp;origin=steveblank.com&amp;obj_id=6599589-33737-69dba887ba35f' data-name='like-post-frame-6599589-33737-69dba887ba35f' data-title='Like or Reblog'><h3 class="sd-title">Like this:</h3><div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='button'><span>Like</span></span> <span class="loading">Loading...</span></div><span class='sd-text-color'></span><a class='sd-link-color'></a></div>					
+					<p class="postinfo">
+						Filed under: <a href="https://steveblank.com/category/national-security/" rel="category tag">National Security</a>, <a href="https://steveblank.com/category/technology-innovation-and-modern-war-2/" rel="category tag">Technology Innovation and Modern War</a> &#124;					</p>
+
+				</div>
+			</div>
+
+
+
+			<div class="browse">&laquo; <a href="https://steveblank.com/2026/03/31/solving-yesterdays-problems-will-kill-you/" rel="prev">Solving Yesterday&#8217;s Problems Will Kill You</a> </div>
+
+
+
+		</div><!-- End content -->
+
+	</div></div><!-- End narrowcolumnwrapper and narrowcolumn classes -->
+
+	
+<div class="narrowcolumnwrapper"><div class="narrowcolumn">
+	<div class="content">
+	<div class="post post-33737 type-post status-publish format-standard hentry category-national-security category-technology-innovation-and-modern-war-2">
+
+	<h3 id="comments">4 Responses</h3>
+
+	<ol class="commentlist">
+	
+<li class="comment even thread-even depth-1" id="comment-617038">
+<div id="div-comment-617038">
+	<div class="comment-meta commentmetadata">
+		<div class="avatar"><img alt='' src='https://secure.gravatar.com/avatar/?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=64&#038;d=mm&#038;r=g 2x' class='avatar avatar-32 photo avatar-default' height='32' width='32' loading='lazy' decoding='async'/></div>		<span class="comment-author vcard"><strong class="fn">Anonymous</strong>, on <a href="#comment-617038" title="">April 9, 2026 at 9:40 am</a> said:		</span>
+			</div>
+
+	<p>We are arriving at the end stage gamification of the war machine. Nuclear annihilation is being replaced with anti-personnel drones and anti-population swarms. We have known about this eventuality for 20+ years but have done nothing to stop it. You are right that the only option for the militaries is underground but they will need to surface at some point. How long can they be above ground before they are attacked &#8211; maybe just a few minutes. </p>
+<p>Unfortunately, it is also the only option for the public.</p>
+<div class='jetpack-comment-likes-widget-wrapper jetpack-likes-widget-unloaded' id='like-comment-wrapper-6599589-617038-69dba887bc112' data-src='https://widgets.wp.com/likes/#blog_id=6599589&amp;comment_id=617038&amp;origin=steveblank.com&amp;obj_id=6599589-617038-69dba887bc112' data-name='like-comment-frame-6599589-617038-69dba887bc112'>
+<div class='likes-widget-placeholder comment-likes-widget-placeholder comment-likes'><span class='loading'>Loading...</span></div>
+<div class='comment-likes-widget jetpack-likes-widget comment-likes'><span class='comment-like-feedback'></span><span class='sd-text-color'></span><a class='sd-link-color'></a></div>
+</div>
+
+	<div class="reply">
+		<a rel="nofollow" class="comment-reply-link" href="https://steveblank.com/2026/04/09/nowhere-is-safe/?replytocom=617038#respond" data-commentid="617038" data-postid="33737" data-belowelement="div-comment-617038" data-respondelement="respond" data-replyto="Reply to Anonymous" aria-label="Reply to Anonymous">Reply</a>	</div>
+</div>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-odd thread-alt depth-1" id="comment-617062">
+<div id="div-comment-617062">
+	<div class="comment-meta commentmetadata">
+		<div class="avatar"><img alt='' src='https://secure.gravatar.com/avatar/?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=64&#038;d=mm&#038;r=g 2x' class='avatar avatar-32 photo avatar-default' height='32' width='32' loading='lazy' decoding='async'/></div>		<span class="comment-author vcard"><strong class="fn">Anonymous</strong>, on <a href="#comment-617062" title="">April 10, 2026 at 3:50 pm</a> said:		</span>
+			</div>
+
+	<p>I mean we&#8217;ve been loose-y goose-y about drone defense to the point I&#8217;m SHOCKED that we haven&#8217;t lost an airframe CONUS. </p>
+<p>The B-1 is only stationed at 2 bases with public access &lt;2mi from the flight line. Often with all or most birds out of hangars. </p>
+<p>The B-2 is only stationed at 1 base with public access &lt;1mi from the flight line and hangars. </p>
+<p>The US is not prepared at all for near-peer conflict.</p>
+<div class='jetpack-comment-likes-widget-wrapper jetpack-likes-widget-unloaded' id='like-comment-wrapper-6599589-617062-69dba887bc67f' data-src='https://widgets.wp.com/likes/#blog_id=6599589&amp;comment_id=617062&amp;origin=steveblank.com&amp;obj_id=6599589-617062-69dba887bc67f' data-name='like-comment-frame-6599589-617062-69dba887bc67f'>
+<div class='likes-widget-placeholder comment-likes-widget-placeholder comment-likes'><span class='loading'>Loading...</span></div>
+<div class='comment-likes-widget jetpack-likes-widget comment-likes'><span class='comment-like-feedback'></span><span class='sd-text-color'></span><a class='sd-link-color'></a></div>
+</div>
+
+	<div class="reply">
+		<a rel="nofollow" class="comment-reply-link" href="https://steveblank.com/2026/04/09/nowhere-is-safe/?replytocom=617062#respond" data-commentid="617062" data-postid="33737" data-belowelement="div-comment-617062" data-respondelement="respond" data-replyto="Reply to Anonymous" aria-label="Reply to Anonymous">Reply</a>	</div>
+</div>
+</li><!-- #comment-## -->
+
+<li class="comment even thread-even depth-1" id="comment-617065">
+<div id="div-comment-617065">
+	<div class="comment-meta commentmetadata">
+		<div class="avatar"><img alt='' src='https://secure.gravatar.com/avatar/5e28f0395197197a510e358c3f074198123bc6aa8a839fbebf69e8d8afbbfaad?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/5e28f0395197197a510e358c3f074198123bc6aa8a839fbebf69e8d8afbbfaad?s=64&#038;d=mm&#038;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' loading='lazy' decoding='async'/></div>		<span class="comment-author vcard"><strong class="fn">Van</strong>, on <a href="#comment-617065" title="">April 10, 2026 at 5:11 pm</a> said:		</span>
+			</div>
+
+	<p>We&#8217;ll get to this after we fix all the potholes&#8230; highways&#8230;.bridges&#8230;</p>
+<div class='jetpack-comment-likes-widget-wrapper jetpack-likes-widget-unloaded' id='like-comment-wrapper-6599589-617065-69dba887bcba2' data-src='https://widgets.wp.com/likes/#blog_id=6599589&amp;comment_id=617065&amp;origin=steveblank.com&amp;obj_id=6599589-617065-69dba887bcba2' data-name='like-comment-frame-6599589-617065-69dba887bcba2'>
+<div class='likes-widget-placeholder comment-likes-widget-placeholder comment-likes'><span class='loading'>Loading...</span></div>
+<div class='comment-likes-widget jetpack-likes-widget comment-likes'><span class='comment-like-feedback'></span><span class='sd-text-color'></span><a class='sd-link-color'></a></div>
+</div>
+
+	<div class="reply">
+		<a rel="nofollow" class="comment-reply-link" href="https://steveblank.com/2026/04/09/nowhere-is-safe/?replytocom=617065#respond" data-commentid="617065" data-postid="33737" data-belowelement="div-comment-617065" data-respondelement="respond" data-replyto="Reply to Van" aria-label="Reply to Van">Reply</a>	</div>
+</div>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-odd thread-alt depth-1" id="comment-617067">
+<div id="div-comment-617067">
+	<div class="comment-meta commentmetadata">
+		<div class="avatar"><img alt='' src='https://secure.gravatar.com/avatar/?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=64&#038;d=mm&#038;r=g 2x' class='avatar avatar-32 photo avatar-default' height='32' width='32' loading='lazy' decoding='async'/></div>		<span class="comment-author vcard"><strong class="fn">Anonymous</strong>, on <a href="#comment-617067" title="">April 10, 2026 at 9:49 pm</a> said:		</span>
+			</div>
+
+	<p>&gt;the U.S. has not fought a foreign force on American soil since 1812</p>
+<p><a href="https://en.wikipedia.org/wiki/Battle_of_Attu" rel="nofollow ugc">https://en.wikipedia.org/wiki/Battle_of_Attu</a></p>
+<div class='jetpack-comment-likes-widget-wrapper jetpack-likes-widget-unloaded' id='like-comment-wrapper-6599589-617067-69dba887bd0ca' data-src='https://widgets.wp.com/likes/#blog_id=6599589&amp;comment_id=617067&amp;origin=steveblank.com&amp;obj_id=6599589-617067-69dba887bd0ca' data-name='like-comment-frame-6599589-617067-69dba887bd0ca'>
+<div class='likes-widget-placeholder comment-likes-widget-placeholder comment-likes'><span class='loading'>Loading...</span></div>
+<div class='comment-likes-widget jetpack-likes-widget comment-likes'><span class='comment-like-feedback'></span><span class='sd-text-color'></span><a class='sd-link-color'></a></div>
+</div>
+
+	<div class="reply">
+		<a rel="nofollow" class="comment-reply-link" href="https://steveblank.com/2026/04/09/nowhere-is-safe/?replytocom=617067#respond" data-commentid="617067" data-postid="33737" data-belowelement="div-comment-617067" data-respondelement="respond" data-replyto="Reply to Anonymous" aria-label="Reply to Anonymous">Reply</a>	</div>
+</div>
+</li><!-- #comment-## -->
+	</ol>
+
+	<div class="navigation">
+	<div class="alignleft"></div>
+	<div class="alignright"></div>
+	</div>
+
+	
+
+
+
+
+		<div id="respond" class="comment-respond">
+			<h3 id="reply-title" class="comment-reply-title">Leave a Reply<small><a rel="nofollow" id="cancel-comment-reply-link" href="/2026/04/09/nowhere-is-safe/#respond" style="display:none;">Cancel reply</a></small></h3>			<form id="commentform" class="comment-form">
+				<iframe
+					title="Comment Form"
+					src="https://jetpack.wordpress.com/jetpack-comment/?blogid=6599589&#038;postid=33737&#038;comment_registration=0&#038;require_name_email=0&#038;stc_enabled=1&#038;stb_enabled=1&#038;show_avatars=1&#038;avatar_default=mystery&#038;greeting=Leave+a+Reply&#038;jetpack_comments_nonce=bdf9329761&#038;greeting_reply=Leave+a+Reply+to+%25s&#038;color_scheme=light&#038;lang=en_US&#038;jetpack_version=15.7&#038;iframe_unique_id=1&#038;show_cookie_consent=10&#038;has_cookie_consent=0&#038;is_current_user_subscribed=0&#038;token_key=%3Bnormal%3B&#038;sig=0b5878f62bc500401ebed2ac3ec4604403ac4e40#parent=https%3A%2F%2Fsteveblank.com%2F2026%2F04%2F09%2Fnowhere-is-safe%2F"
+											name="jetpack_remote_comment"
+						style="width:100%; height: 430px; border:0;"
+										class="jetpack_remote_comment"
+					id="jetpack_remote_comment"
+					sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms allow-popups"
+				>
+									</iframe>
+									<!--[if !IE]><!-->
+					<script>
+						document.addEventListener('DOMContentLoaded', function () {
+							var commentForms = document.getElementsByClassName('jetpack_remote_comment');
+							for (var i = 0; i < commentForms.length; i++) {
+								commentForms[i].allowTransparency = false;
+								commentForms[i].scrolling = 'no';
+							}
+						});
+					</script>
+					<!--<![endif]-->
+							</form>
+		</div>
+
+		
+		<input type="hidden" name="comment_parent" id="comment_parent" value="" />
+
+		
+	</div>
+	</div>
+</div></div>
+
+
+	</div><!-- End wrapper class -->
+
+	<div class="sidebar">
+	<ul>
+
+<li id="block-2" class="widget widget_block widget_text">
+<p><span style="color:#2E2EFE;"><span style="font-size:.9em;">
+ contact: info@kandsranch.com</span>
+</span></p>
+</li>
+<li id="block-3" class="widget widget_block"><div style="height:10px;"></div></li>
+<li id="block-4" class="widget widget_block"><div style="text-align:center;"> <img decoding="async" src="https://steveblank.com/wp-content/uploads/2014/08/twitter-log.png">
+<a href="http://twitter.com/sgblank" target="_blank">@sgblank</a>
+<div style="height:20px;"></div>
+
+<a href="https://www.linkedin.com/in/steveblank/"><img decoding="async" src="https://steveblank.com/wp-content/uploads/2014/08/linkedin1.png">
+</a>
+<div style="height:20px;"></div>
+
+<a href="https://www.americasfrontier.com/aff-resources">
+<img decoding="async" style="border:1px solid black;" src="https://steveblank.com/wp-content/uploads/2026/01/Directory-title-page-1.jpg">
+</a>
+<div style="height:20px;"></div>
+
+<a href="https://www.amazon.com/Startup-Owners-Manual-Step-Step/dp/1119690684/">
+<img decoding="async" style="border:1px solid black;" src="https://steveblank.com/wp-content/uploads/2014/09/new-som-blog-pic.jpg">
+</a>
+<div style="height:20px;"></div>
+
+<a href="http://hbr.org/2013/05/why-the-lean-start-up-changes-everything/ar/1"><img decoding="async" style="border:1px solid black;" src="http://steveblank.com/wp-content/uploads/2013/05/hbr-reprint1.jpg">
+</a>
+<div style="height:20px;"></div>
+
+<a href="https://www.amazon.com/Four-Steps-Epiphany-Successful-Strategies-dp-1119690358/dp/1119690358/"><img decoding="async" style="border:1px solid black;" src="http://steveblank.com/wp-content/uploads/2013/07/four-steps-hardcover-150.jpg"></a>
+
+<div style="height:20px;"></div>
+
+<a href="http://clearshore.net/"><img decoding="async" style="border:1px solid black;" src="https://steveblank.com/wp-content/uploads/2017/08/sbpodcastbutton_final.png">Get the Podcasts for Free</a></div></li>
+<li id="block-5" class="widget widget_block widget_text">
+<p></p>
+</li>
+
+</ul>
+	</div>
+</div><!-- End pagewrapper -->
+
+<div id="footer">
+<p><a href="https://wordpress.com/?ref=footer_custom_powered">Powered by WordPress.com</a>. WP Designer.</p>
+</div>
+
+</div><!-- end page -->
+
+</div><!-- End container id -->
+
+<!--  -->
+<script type="speculationrules">
+{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"/*"},{"not":{"href_matches":["/wp-*.php","/wp-admin/*","/wp-content/uploads/*","/wp-content/*","/wp-content/plugins/*","/wp-content/themes/digg3/*","/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
+</script>
+<meta id="bilmur" property="bilmur:data" content="" data-customproperties="{&quot;woo_active&quot;:&quot;0&quot;,&quot;logged_in&quot;:&quot;0&quot;,&quot;wptheme&quot;:&quot;digg3&quot;,&quot;wptheme_is_block&quot;:&quot;0&quot;}" data-provider="wordpress.com" data-service="atomic"  data-site-tz="America/Los_Angeles" >
+<script defer src="https://s0.wp.com/wp-content/js/bilmur.min.js?m=202615"></script>
+					<div class="jetpack-subscription-modal">
+						<div class="jetpack-subscription-modal__modal-content">
+								
+	<div class="wp-block-group has-border-color jetpack-subscription-modal__modal-content-form" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding:32px"><div class="wp-block-group__inner-container is-layout-flow wp-block-group-is-layout-flow">
+
+		
+		<h2 class="wp-block-heading has-text-align-center" style="margin-top:4px;margin-bottom:10px;font-size:26px;font-style:normal;font-weight:600">Discover more from Steve Blank</h2>
+		
+
+		
+		<p class='has-text-align-center' style='margin-top:4px;margin-bottom:0px;font-size:15px'>Subscribe now to keep reading and get access to the full archive.</p>
+		
+
+			<div class="wp-block-jetpack-subscriptions__supports-newline is-style-compact wp-block-jetpack-subscriptions">
+		<div class="wp-block-jetpack-subscriptions__container is-not-subscriber">
+							<form
+					action="https://wordpress.com/email-subscriptions"
+					method="post"
+					accept-charset="utf-8"
+					data-blog="6599589"
+					data-post_access_level="everybody"
+					data-subscriber_email=""
+					id="subscribe-blog-2"
+				>
+					<div class="wp-block-jetpack-subscriptions__form-elements">
+												<p id="subscribe-email">
+							<label
+								id="subscribe-field-2-label"
+								for="subscribe-field-2"
+								class="screen-reader-text"
+							>
+								Type your email…							</label>
+							<input
+									required="required"
+									type="email"
+									name="email"
+									autocomplete="email"
+									
+									style="font-size: 16px;padding: 15px 23px 15px 23px;border-radius: 50px;border-width: 1px;"
+									placeholder="Type your email…"
+									value=""
+									id="subscribe-field-2"
+									title="Please fill in this field."
+								/>						</p>
+												<p id="subscribe-submit"
+													>
+							<input type="hidden" name="action" value="subscribe"/>
+							<input type="hidden" name="blog_id" value="6599589"/>
+							<input type="hidden" name="source" value="https://steveblank.com/2026/04/09/nowhere-is-safe/"/>
+							<input type="hidden" name="sub-type" value="subscribe-block"/>
+							<input type="hidden" name="app_source" value="atomic-subscription-modal-lo"/>
+							<input type="hidden" name="redirect_fragment" value="subscribe-blog-2"/>
+							<input type="hidden" name="lang" value="en_US"/>
+							<input type="hidden" id="_wpnonce" name="_wpnonce" value="d9a58a43d8" /><input type="hidden" name="_wp_http_referer" value="/2026/04/09/nowhere-is-safe/" /><input type="hidden" name="post_id" value="33737"/>							<button type="submit"
+																	class="wp-block-button__link"
+																									style="font-size: 16px;padding: 15px 23px 15px 23px;margin: 0; margin-left: 10px;border-radius: 50px;border-width: 1px;"
+																name="jetpack_subscriptions_widget"
+							>
+								Subscribe							</button>
+						</p>
+					</div>
+				</form>
+								</div>
+	</div>
+	
+
+		
+		<p class="has-text-align-center jetpack-subscription-modal__close" style="margin-top:20px;font-size:14px"><a href="#">Continue reading</a></p>
+		
+	</div></div>
+							</div>
+					</div>
+				<div style="display:none">
+			<div class="grofile-hash-map-2e61deb4817e778e595fe280b1d64dd4">
+		</div>
+		</div>
+				<div id="jp-carousel-loading-overlay">
+			<div id="jp-carousel-loading-wrapper">
+				<span id="jp-carousel-library-loading">&nbsp;</span>
+			</div>
+		</div>
+		<div class="jp-carousel-overlay" style="display: none;">
+
+		<div class="jp-carousel-container">
+			<!-- The Carousel Swiper -->
+			<div
+				class="jp-carousel-wrap swiper jp-carousel-swiper-container jp-carousel-transitions"
+				itemscope
+				itemtype="https://schema.org/ImageGallery">
+				<div class="jp-carousel swiper-wrapper"></div>
+				<div class="jp-swiper-button-prev swiper-button-prev">
+					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<mask id="maskPrev" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="9" height="12">
+							<path d="M16.2072 16.59L11.6496 12L16.2072 7.41L14.8041 6L8.8335 12L14.8041 18L16.2072 16.59Z" fill="white"/>
+						</mask>
+						<g mask="url(#maskPrev)">
+							<rect x="0.579102" width="23.8823" height="24" fill="#FFFFFF"/>
+						</g>
+					</svg>
+				</div>
+				<div class="jp-swiper-button-next swiper-button-next">
+					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<mask id="maskNext" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="8" height="12">
+							<path d="M8.59814 16.59L13.1557 12L8.59814 7.41L10.0012 6L15.9718 12L10.0012 18L8.59814 16.59Z" fill="white"/>
+						</mask>
+						<g mask="url(#maskNext)">
+							<rect x="0.34375" width="23.8822" height="24" fill="#FFFFFF"/>
+						</g>
+					</svg>
+				</div>
+			</div>
+			<!-- The main close buton -->
+			<div class="jp-carousel-close-hint">
+				<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<mask id="maskClose" mask-type="alpha" maskUnits="userSpaceOnUse" x="5" y="5" width="15" height="14">
+						<path d="M19.3166 6.41L17.9135 5L12.3509 10.59L6.78834 5L5.38525 6.41L10.9478 12L5.38525 17.59L6.78834 19L12.3509 13.41L17.9135 19L19.3166 17.59L13.754 12L19.3166 6.41Z" fill="white"/>
+					</mask>
+					<g mask="url(#maskClose)">
+						<rect x="0.409668" width="23.8823" height="24" fill="#FFFFFF"/>
+					</g>
+				</svg>
+			</div>
+			<!-- Image info, comments and meta -->
+			<div class="jp-carousel-info">
+				<div class="jp-carousel-info-footer">
+					<div class="jp-carousel-pagination-container">
+						<div class="jp-swiper-pagination swiper-pagination"></div>
+						<div class="jp-carousel-pagination"></div>
+					</div>
+					<div class="jp-carousel-photo-title-container">
+						<h2 class="jp-carousel-photo-caption"></h2>
+					</div>
+					<div class="jp-carousel-photo-icons-container">
+						<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-info" aria-label="Toggle photo metadata visibility">
+							<span class="jp-carousel-icon">
+								<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<mask id="maskInfo" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
+										<path fill-rule="evenodd" clip-rule="evenodd" d="M12.7537 2C7.26076 2 2.80273 6.48 2.80273 12C2.80273 17.52 7.26076 22 12.7537 22C18.2466 22 22.7046 17.52 22.7046 12C22.7046 6.48 18.2466 2 12.7537 2ZM11.7586 7V9H13.7488V7H11.7586ZM11.7586 11V17H13.7488V11H11.7586ZM4.79292 12C4.79292 16.41 8.36531 20 12.7537 20C17.142 20 20.7144 16.41 20.7144 12C20.7144 7.59 17.142 4 12.7537 4C8.36531 4 4.79292 7.59 4.79292 12Z" fill="white"/>
+									</mask>
+									<g mask="url(#maskInfo)">
+										<rect x="0.8125" width="23.8823" height="24" fill="#FFFFFF"/>
+									</g>
+								</svg>
+							</span>
+						</a>
+												<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-comments" aria-label="Toggle photo comments visibility">
+							<span class="jp-carousel-icon">
+								<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<mask id="maskComments" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
+										<path fill-rule="evenodd" clip-rule="evenodd" d="M4.3271 2H20.2486C21.3432 2 22.2388 2.9 22.2388 4V16C22.2388 17.1 21.3432 18 20.2486 18H6.31729L2.33691 22V4C2.33691 2.9 3.2325 2 4.3271 2ZM6.31729 16H20.2486V4H4.3271V18L6.31729 16Z" fill="white"/>
+									</mask>
+									<g mask="url(#maskComments)">
+										<rect x="0.34668" width="23.8823" height="24" fill="#FFFFFF"/>
+									</g>
+								</svg>
+
+								<span class="jp-carousel-has-comments-indicator" aria-label="This image has comments."></span>
+							</span>
+						</a>
+											</div>
+				</div>
+				<div class="jp-carousel-info-extra">
+					<div class="jp-carousel-info-content-wrapper">
+						<div class="jp-carousel-photo-title-container">
+							<h2 class="jp-carousel-photo-title"></h2>
+						</div>
+						<div class="jp-carousel-comments-wrapper">
+															<div id="jp-carousel-comments-loading">
+									<span>Loading Comments...</span>
+								</div>
+								<div class="jp-carousel-comments"></div>
+								<div id="jp-carousel-comment-form-container">
+									<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
+									<div id="jp-carousel-comment-post-results"></div>
+																														<form id="jp-carousel-comment-form">
+												<label for="jp-carousel-comment-form-comment-field" class="screen-reader-text">Write a Comment...</label>
+												<textarea
+													name="comment"
+													class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
+													id="jp-carousel-comment-form-comment-field"
+													placeholder="Write a Comment..."
+												></textarea>
+												<div id="jp-carousel-comment-form-submit-and-info-wrapper">
+													<div id="jp-carousel-comment-form-commenting-as">
+																													<fieldset>
+																<label for="jp-carousel-comment-form-email-field">Email</label>
+																<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
+															</fieldset>
+															<fieldset>
+																<label for="jp-carousel-comment-form-author-field">Name</label>
+																<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
+															</fieldset>
+															<fieldset>
+																<label for="jp-carousel-comment-form-url-field">Website</label>
+																<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
+															</fieldset>
+																											</div>
+													<input
+														type="submit"
+														name="submit"
+														class="jp-carousel-comment-form-button"
+														id="jp-carousel-comment-form-button-submit"
+														value="Post Comment" />
+												</div>
+											</form>
+																											</div>
+													</div>
+						<div class="jp-carousel-image-meta">
+							<div class="jp-carousel-title-and-caption">
+								<div class="jp-carousel-photo-info">
+									<h3 class="jp-carousel-caption" itemprop="caption description"></h3>
+								</div>
+
+								<div class="jp-carousel-photo-description"></div>
+							</div>
+							<ul class="jp-carousel-image-exif" style="display: none;"></ul>
+							<a class="jp-carousel-image-download" href="#" target="_blank" style="display: none;">
+								<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="19" height="18">
+										<path fill-rule="evenodd" clip-rule="evenodd" d="M5.84615 5V19H19.7775V12H21.7677V19C21.7677 20.1 20.8721 21 19.7775 21H5.84615C4.74159 21 3.85596 20.1 3.85596 19V5C3.85596 3.9 4.74159 3 5.84615 3H12.8118V5H5.84615ZM14.802 5V3H21.7677V10H19.7775V6.41L9.99569 16.24L8.59261 14.83L18.3744 5H14.802Z" fill="white"/>
+									</mask>
+									<g mask="url(#mask0)">
+										<rect x="0.870605" width="23.8823" height="24" fill="#FFFFFF"/>
+									</g>
+								</svg>
+								<span class="jp-carousel-download-text"></span>
+							</a>
+							<div class="jp-carousel-image-map" style="display: none;"></div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		</div>
+		
+	<script type="text/javascript">
+		window.WPCOM_sharing_counts = {"https://steveblank.com/2026/04/09/nowhere-is-safe/":33737};
+	</script>
+							<div id="fb-root"></div>
+			<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;appId=249643311490&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
+			<script>
+			document.body.addEventListener( 'is.post-load', function() {
+				if ( 'undefined' !== typeof FB ) {
+					FB.XFBML.parse();
+				}
+			} );
+			</script>
+						<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+						<script type="text/javascript">
+				( function () {
+					var currentScript = document.currentScript;
+
+					// Helper function to load an external script.
+					function loadScript( url, cb ) {
+						var script = document.createElement( 'script' );
+						var prev = currentScript || document.getElementsByTagName( 'script' )[ 0 ];
+						script.setAttribute( 'async', true );
+						script.setAttribute( 'src', url );
+						prev.parentNode.insertBefore( script, prev );
+						script.addEventListener( 'load', cb );
+					}
+
+					function init() {
+						loadScript( 'https://platform.linkedin.com/in.js?async=true', function () {
+							if ( typeof IN !== 'undefined' ) {
+								IN.init();
+							}
+						} );
+					}
+
+					if ( document.readyState === 'loading' ) {
+						document.addEventListener( 'DOMContentLoaded', init );
+					} else {
+						init();
+					}
+
+					document.body.addEventListener( 'is.post-load', function() {
+						if ( typeof IN !== 'undefined' ) {
+							IN.parse();
+						}
+					} );
+				} )();
+			</script>
+								<script type="text/javascript">
+				( function () {
+					// Pinterest shared resources
+					var s = document.createElement( 'script' );
+					s.type = 'text/javascript';
+					s.async = true;
+					s.setAttribute( 'data-pin-hover', true );					s.src = window.location.protocol + '//assets.pinterest.com/js/pinit.js';
+					var x = document.getElementsByTagName( 'script' )[ 0 ];
+					x.parentNode.insertBefore(s, x);
+					// if 'Pin it' button has 'counts' make container wider
+					function init() {
+						var shares = document.querySelectorAll( 'li.share-pinterest' );
+						for ( var i = 0; i < shares.length; i++ ) {
+							var share = shares[ i ];
+							var countElement = share.querySelector( 'a span' );
+							if (countElement) {
+								var countComputedStyle = window.getComputedStyle(countElement);
+								if ( countComputedStyle.display === 'block' ) {
+									var countWidth = parseInt( countComputedStyle.width, 10 );
+									share.style.marginRight = countWidth + 11 + 'px';
+								}
+							}
+						}
+					}
+
+					if ( document.readyState !== 'complete' ) {
+						document.addEventListener( 'load', init );
+					} else {
+						init();
+					}
+				} )();
+			</script>
+					<script id="tumblr-js" type="text/javascript" src="https://assets.tumblr.com/share-button.js"></script>
+			<script type="text/javascript" src="https://steveblank.com/wp-includes/js/comment-reply.min.js?ver=6.9.4" id="comment-reply-js" async="async" data-wp-strategy="async" fetchpriority="low"></script>
+<script type="text/javascript" id="subscription-modal-js-js-extra">
+/* <![CDATA[ */
+var subscriptionData = {"homeUrl":"steveblank.com"};
+//# sourceURL=subscription-modal-js-js-extra
+/* ]]> */
+</script>
+<script type='text/javascript'  src='https://steveblank.com/_static/??wp-includes/js/dist/dom-ready.min.js,wp-content/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js?m=1764003632'></script>
+<script type="text/javascript" src="https://secure.gravatar.com/js/gprofiles.js?ver=202615" id="grofiles-cards-js"></script>
+<script type="text/javascript" id="wpgroho-js-extra">
+/* <![CDATA[ */
+var WPGroHo = {"my_hash":""};
+//# sourceURL=wpgroho-js-extra
+/* ]]> */
+</script>
+<script type='text/javascript'  src='https://steveblank.com/_static/??wp-content/plugins/jetpack/modules/wpgroho.js,wp-content/plugins/jetpack/_inc/build/likes/queuehandler.min.js?m=1764003632'></script>
+<script type="text/javascript" id="jetpack-stats-js-before">
+/* <![CDATA[ */
+_stq = window._stq || [];
+_stq.push([ "view", {"v":"ext","blog":"6599589","post":"33737","tz":"-7","srv":"steveblank.com","hp":"atomic","ac":"2","amp":"0","j":"1:15.7"} ]);
+_stq.push([ "clickTrackerInit", "6599589", "33737" ]);
+//# sourceURL=jetpack-stats-js-before
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://stats.wp.com/e-202615.js" id="jetpack-stats-js" defer="defer" data-wp-strategy="defer"></script>
+<script type="text/javascript" id="jetpack-carousel-js-extra">
+/* <![CDATA[ */
+var jetpackSwiperLibraryPath = {"url":"https://steveblank.com/wp-content/plugins/jetpack/_inc/blocks/swiper.js"};
+var jetpackCarouselStrings = {"widths":[370,700,1000,1200,1400,2000],"is_logged_in":"","lang":"en","ajaxurl":"https://steveblank.com/wp-admin/admin-ajax.php","nonce":"437fbc5e98","display_exif":"1","display_comments":"1","single_image_gallery":"1","single_image_gallery_media_file":"","background_color":"black","comment":"Comment","post_comment":"Post Comment","write_comment":"Write a Comment...","loading_comments":"Loading Comments...","image_label":"Open image in full-screen.","download_original":"View full size \u003Cspan class=\"photo-size\"\u003E{0}\u003Cspan class=\"photo-size-times\"\u003E\u00d7\u003C/span\u003E{1}\u003C/span\u003E","no_comment_text":"Please be sure to submit some text with your comment.","no_comment_email":"Please provide an email address to comment.","no_comment_author":"Please provide your name to comment.","comment_post_error":"Sorry, but there was an error posting your comment. Please try again later.","comment_approved":"Your comment was approved.","comment_unapproved":"Your comment is in moderation.","camera":"Camera","aperture":"Aperture","shutter_speed":"Shutter Speed","focal_length":"Focal Length","copyright":"Copyright","comment_registration":"0","require_name_email":"0","login_url":"https://steveblank.com/wp-login.php?redirect_to=https%3A%2F%2Fsteveblank.com%2F2026%2F04%2F09%2Fnowhere-is-safe%2F","blog_id":"1","meta_data":["camera","aperture","shutter_speed","focal_length","copyright"]};
+//# sourceURL=jetpack-carousel-js-extra
+/* ]]> */
+</script>
+<script type='text/javascript'  src='https://steveblank.com/wp-content/plugins/jetpack/_inc/build/carousel/jetpack-carousel.min.js?m=1775503892'></script>
+<script defer type="text/javascript" src="https://steveblank.com/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1704837122" id="akismet-frontend-js"></script>
+<script type="text/javascript" id="jetpack-blocks-assets-base-url-js-before">
+/* <![CDATA[ */
+var Jetpack_Block_Assets_Base_Url="https://steveblank.com/wp-content/plugins/jetpack/_inc/blocks/";
+//# sourceURL=jetpack-blocks-assets-base-url-js-before
+/* ]]> */
+</script>
+<script type='text/javascript'  src='https://steveblank.com/wp-includes/js/dist/vendor/wp-polyfill.min.js?m=1761030842'></script>
+<script type="text/javascript" src="https://steveblank.com/wp-content/plugins/jetpack/_inc/blocks/subscriptions/view.js?minify=false&amp;ver=15.7" id="jetpack-block-subscriptions-js" defer="defer" data-wp-strategy="defer"></script>
+<script type="text/javascript" id="sharing-js-js-extra">
+/* <![CDATA[ */
+var sharing_js_options = {"lang":"en","counts":"1","is_stats_active":"1"};
+//# sourceURL=sharing-js-js-extra
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://steveblank.com/wp-content/plugins/jetpack/_inc/build/sharedaddy/sharing.min.js?ver=15.7" id="sharing-js-js"></script>
+<script type="text/javascript" id="sharing-js-js-after">
+/* <![CDATA[ */
+var windowOpen;
+			( function () {
+				function matches( el, sel ) {
+					return !! (
+						el.matches && el.matches( sel ) ||
+						el.msMatchesSelector && el.msMatchesSelector( sel )
+					);
+				}
+
+				document.body.addEventListener( 'click', function ( event ) {
+					if ( ! event.target ) {
+						return;
+					}
+
+					var el;
+					if ( matches( event.target, 'a.share-facebook' ) ) {
+						el = event.target;
+					} else if ( event.target.parentNode && matches( event.target.parentNode, 'a.share-facebook' ) ) {
+						el = event.target.parentNode;
+					}
+
+					if ( el ) {
+						event.preventDefault();
+
+						// If there's another sharing window open, close it.
+						if ( typeof windowOpen !== 'undefined' ) {
+							windowOpen.close();
+						}
+						windowOpen = window.open( el.getAttribute( 'href' ), 'wpcomfacebook', 'menubar=1,resizable=1,width=600,height=400' );
+						return false;
+					}
+				} );
+			} )();
+var windowOpen;
+			( function () {
+				function matches( el, sel ) {
+					return !! (
+						el.matches && el.matches( sel ) ||
+						el.msMatchesSelector && el.msMatchesSelector( sel )
+					);
+				}
+
+				document.body.addEventListener( 'click', function ( event ) {
+					if ( ! event.target ) {
+						return;
+					}
+
+					var el;
+					if ( matches( event.target, 'a.share-telegram' ) ) {
+						el = event.target;
+					} else if ( event.target.parentNode && matches( event.target.parentNode, 'a.share-telegram' ) ) {
+						el = event.target.parentNode;
+					}
+
+					if ( el ) {
+						event.preventDefault();
+
+						// If there's another sharing window open, close it.
+						if ( typeof windowOpen !== 'undefined' ) {
+							windowOpen.close();
+						}
+						windowOpen = window.open( el.getAttribute( 'href' ), 'wpcomtelegram', 'menubar=1,resizable=1,width=450,height=450' );
+						return false;
+					}
+				} );
+			} )();
+//# sourceURL=sharing-js-js-after
+/* ]]> */
+</script>
+<script id="wp-emoji-settings" type="application/json">
+{"baseUrl":"https://s.w.org/images/core/emoji/17.0.2/72x72/","ext":".png","svgUrl":"https://s.w.org/images/core/emoji/17.0.2/svg/","svgExt":".svg","source":{"concatemoji":"https://steveblank.com/wp-includes/js/wp-emoji-release.min.js?ver=6.9.4"}}
+</script>
+<script type="module">
+/* <![CDATA[ */
+/*! This file is auto-generated */
+const a=JSON.parse(document.getElementById("wp-emoji-settings").textContent),o=(window._wpemojiSettings=a,"wpEmojiSettingsSupports"),s=["flag","emoji"];function i(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function c(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data);e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0);const a=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data);return t.every((e,t)=>e===a[t])}function p(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var n=e.getImageData(16,16,1,1);for(let e=0;e<n.data.length;e++)if(0!==n.data[e])return!1;return!0}function u(e,t,n,a){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\udde8\ud83c\uddf6","\ud83c\udde8\u200b\ud83c\uddf6")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!a(e,"\ud83e\u1fac8")}return!1}function f(e,t,n,a){let r;const o=(r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):document.createElement("canvas")).getContext("2d",{willReadFrequently:!0}),s=(o.textBaseline="top",o.font="600 32px Arial",{});return e.forEach(e=>{s[e]=t(o,e,n,a)}),s}function r(e){var t=document.createElement("script");t.src=e,t.defer=!0,document.head.appendChild(t)}a.supports={everything:!0,everythingExceptFlag:!0},new Promise(t=>{let n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),c.toString(),p.toString()].join(",")+"));",a=new Blob([e],{type:"text/javascript"});const r=new Worker(URL.createObjectURL(a),{name:"wpTestEmojiSupports"});return void(r.onmessage=e=>{i(n=e.data),r.terminate(),t(n)})}catch(e){}i(n=f(s,u,c,p))}t(n)}).then(e=>{for(const n in e)a.supports[n]=e[n],a.supports.everything=a.supports.everything&&a.supports[n],"flag"!==n&&(a.supports.everythingExceptFlag=a.supports.everythingExceptFlag&&a.supports[n]);var t;a.supports.everythingExceptFlag=a.supports.everythingExceptFlag&&!a.supports.flag,a.supports.everything||((t=a.source||{}).concatemoji?r(t.concatemoji):t.wpemoji&&t.twemoji&&(r(t.twemoji),r(t.wpemoji)))});
+//# sourceURL=https://steveblank.com/wp-includes/js/wp-emoji-loader.min.js
+/* ]]> */
+</script>
+	<iframe src='https://widgets.wp.com/likes/master.html?ver=20260412#ver=20260412' scrolling='no' id='likes-master' name='likes-master' style='display:none;'></iframe>
+	<div id='likes-other-gravatars' role="dialog" aria-hidden="true" tabindex="-1"><div class="likes-text"><span>%d</span></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
+			<script type="text/javascript">
+			(function () {
+				const iframe = document.getElementById( 'jetpack_remote_comment' );
+								const watchReply = function() {
+					// Check addComment._Jetpack_moveForm to make sure we don't monkey-patch twice.
+					if ( 'undefined' !== typeof addComment && ! addComment._Jetpack_moveForm ) {
+						// Cache the Core function.
+						addComment._Jetpack_moveForm = addComment.moveForm;
+						const commentParent = document.getElementById( 'comment_parent' );
+						const cancel = document.getElementById( 'cancel-comment-reply-link' );
+
+						function tellFrameNewParent ( commentParentValue ) {
+							const url = new URL( iframe.src );
+							if ( commentParentValue ) {
+								url.searchParams.set( 'replytocom', commentParentValue )
+							} else {
+								url.searchParams.delete( 'replytocom' );
+							}
+							if( iframe.src !== url.href ) {
+								iframe.src = url.href;
+							}
+						};
+
+						cancel.addEventListener( 'click', function () {
+							tellFrameNewParent( false );
+						} );
+
+						addComment.moveForm = function ( _, parentId ) {
+							tellFrameNewParent( parentId );
+							return addComment._Jetpack_moveForm.apply( null, arguments );
+						};
+					}
+				}
+				document.addEventListener( 'DOMContentLoaded', watchReply );
+				// In WP 6.4+, the script is loaded asynchronously, so we need to wait for it to load before we monkey-patch the functions it introduces.
+				document.querySelector('#comment-reply-js')?.addEventListener( 'load', watchReply );
+
+								
+				const commentIframes = document.getElementsByClassName('jetpack_remote_comment');
+
+				window.addEventListener('message', function(event) {
+					if (event.origin !== 'https://jetpack.wordpress.com') {
+						return;
+					}
+
+					if (!event?.data?.iframeUniqueId && !event?.data?.height) {
+						return;
+					}
+
+					const eventDataUniqueId = event.data.iframeUniqueId;
+
+					// Change height for the matching comment iframe
+					for (let i = 0; i < commentIframes.length; i++) {
+						const iframe = commentIframes[i];
+						const url = new URL(iframe.src);
+						const iframeUniqueIdParam = url.searchParams.get('iframe_unique_id');
+						if (iframeUniqueIdParam == event.data.iframeUniqueId) {
+							iframe.style.height = event.data.height + 'px';
+							return;
+						}
+					}
+				});
+			})();
+		</script>
+		
+</body>
+</html>
+<!--
+	generated 299 seconds ago
+	generated in 0.198 seconds
+	served from batcache in 0.004 seconds
+	expires in 1 seconds
+-->


### PR DESCRIPTION
### Motivation
- 修正放大字體（mobile enforcement）時造成某些頁面行距不足導致文字重疊的回歸問題，並為 `https://steveblank.com/2026/04/09/nowhere-is-safe/` 加入自動化回歸測試以重現與驗證該問題。

### Description
- 將 `src/ForceMobileView.user.js` metadata 版本更新為 `2026-04-12_1.7.0` 並在字體強制邏輯中改為以像素值設定最小 `line-height`（px），取代單純使用比例值，避免放大後行盒重疊。 
- 新增祖先元素補強函式 `enforceReadableLineHeight`，當祖先元素的計算行高過小時會臨時提升並儲存原始 inline 屬性以便還原。 
- 新增用於只存放並還原祖先元素行高的資料屬性（例如 `data-tm-force-width-min-line-height-only*`）並在停用時完整還原所有變更。 
- 新增捕獲頁面 fixture `tests/Force Mobile View/steveblank.com_2026_04_09_nowhere-is-safe.html`，並擴充 `scripts/test-force-mobile-view.js`：載入該 fixture、先模擬舊的「僅放大字體」會重疊的情境，再驗證新邏輯能提升父層行高以避免重疊；同時更新 `TestCases.md` 並標註為自動化測試。 

### Testing
- 執行 `node --test scripts/test-force-mobile-view.js`，所有子測試通過（6 個子測試皆通過）。
- 新增的 Steve Blank 捕獲頁面已加入測試夾具並由本地 DOM harness 模擬重疊情境以驗證修正生效，該自動化測試通過。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba94eeb548322bbe1c214ef7e6b05)