### PR TITLE
在 AllGoInternetArchive / ForceMobileView / ForceDarkMode 新增 exclude 規則

### DIFF
--- a/src/AllGoInternetArchive.user.js
+++ b/src/AllGoInternetArchive.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         All Go InternetArchive Redirect
 // @namespace    http://tampermonkey.net/
-// @version      2025-12-27_1.2.5
+// @version      2026-04-12_1.2.6
 // @description  Add a quick Internet Archive link on any site for testing snapshots.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -9,6 +9,41 @@
 // @updateURL    https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/AllGoInternetArchive.user.js
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=web.archive.org
 // @match        *://*/*
+// @exclude      *://hackernews.betacat.io/*
+// @exclude      *://*.hackernews.betacat.io/*
+// @exclude      *://theneurondaily.com/*
+// @exclude      *://*.theneurondaily.com/*
+// @exclude      *://tam.gov.taipei/*
+// @exclude      *://*.tam.gov.taipei/*
+// @exclude      *://wiwi.*/*
+// @exclude      *://*.wiwi.*/*
+// @exclude      *://*.kagi.com/*
+// @exclude      *://chatgpt.com/*
+// @exclude      *://*.chatgpt.com/*
+// @exclude      *://christorng.github.io/*
+// @exclude      *://github.com/*
+// @exclude      *://discord.com/*
+// @exclude      *://*.discord.com/*
+// @exclude      *://ebird.org/*
+// @exclude      *://*.ebird.org/*
+// @exclude      *://newsminimalist.com/*
+// @exclude      *://*.newsminimalist.com/*
+// @exclude      *://*ycombinator.com/*
+// @exclude      *://huggingface.co/*
+// @exclude      *://*.huggingface.co/*
+// @exclude      *://youtube.com/*
+// @exclude      *://*.youtube.com/*
+// @exclude      *://x.com/*
+// @exclude      *://*.x.com/*
+// @exclude      *://nitter.net/*
+// @exclude      *://*.nitter.net/*
+// @exclude      *://bing.com/*
+// @exclude      *://*.bing.com/*
+// @exclude      *://*.wikipedia.org/*
+// @exclude      *://reddit.com/*
+// @exclude      *://*.reddit.com/*
+// @exclude      *://arxiv.org/*
+// @exclude      *://*.arxiv.org/*
 // @grant        none
 // ==/UserScript==
 

--- a/src/ForceDarkMode.user.js
+++ b/src/ForceDarkMode.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Force Dark Mode
 // @namespace    http://tampermonkey.net/
-// @version      2026-01-18_1.0.1
+// @version      2026-04-12_1.0.2
 // @description  Expose a draggable top-right 🌙 toggle button to force dark mode colors with auto-enable for matched URLs.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -10,6 +10,41 @@
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=www.tampermonkey.net
 // @match        https://www.lesswrong.com/*
 // @match        *://*/*
+// @exclude      *://hackernews.betacat.io/*
+// @exclude      *://*.hackernews.betacat.io/*
+// @exclude      *://theneurondaily.com/*
+// @exclude      *://*.theneurondaily.com/*
+// @exclude      *://tam.gov.taipei/*
+// @exclude      *://*.tam.gov.taipei/*
+// @exclude      *://wiwi.*/*
+// @exclude      *://*.wiwi.*/*
+// @exclude      *://*.kagi.com/*
+// @exclude      *://chatgpt.com/*
+// @exclude      *://*.chatgpt.com/*
+// @exclude      *://christorng.github.io/*
+// @exclude      *://github.com/*
+// @exclude      *://discord.com/*
+// @exclude      *://*.discord.com/*
+// @exclude      *://ebird.org/*
+// @exclude      *://*.ebird.org/*
+// @exclude      *://newsminimalist.com/*
+// @exclude      *://*.newsminimalist.com/*
+// @exclude      *://*ycombinator.com/*
+// @exclude      *://huggingface.co/*
+// @exclude      *://*.huggingface.co/*
+// @exclude      *://youtube.com/*
+// @exclude      *://*.youtube.com/*
+// @exclude      *://x.com/*
+// @exclude      *://*.x.com/*
+// @exclude      *://nitter.net/*
+// @exclude      *://*.nitter.net/*
+// @exclude      *://bing.com/*
+// @exclude      *://*.bing.com/*
+// @exclude      *://*.wikipedia.org/*
+// @exclude      *://reddit.com/*
+// @exclude      *://*.reddit.com/*
+// @exclude      *://arxiv.org/*
+// @exclude      *://*.arxiv.org/*
 // @grant        GM_info
 // @run-at       document-start
 // ==/UserScript==

--- a/src/ForceMobileView.user.js
+++ b/src/ForceMobileView.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Force Mobile View
 // @namespace    http://tampermonkey.net/
-// @version      2026-04-12_1.7.1
+// @version      2026-04-12_1.7.2
 // @description  Keep pages within the viewport width, trim excessive horizontal spacing on all enabled pages, wrap long content, and expose a draggable top-right ↔ toggle button with auto-enable for matched URLs or tiny fonts.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -11,7 +11,41 @@
 // @match        https://news.ycombinator.com/item?*
 // @match        https://archive.is/*
 // @match        *://*/*
+// @exclude      *://hackernews.betacat.io/*
+// @exclude      *://*.hackernews.betacat.io/*
+// @exclude      *://theneurondaily.com/*
+// @exclude      *://*.theneurondaily.com/*
+// @exclude      *://tam.gov.taipei/*
+// @exclude      *://*.tam.gov.taipei/*
+// @exclude      *://wiwi.*/*
+// @exclude      *://*.wiwi.*/*
+// @exclude      *://*.kagi.com/*
+// @exclude      *://chatgpt.com/*
+// @exclude      *://*.chatgpt.com/*
+// @exclude      *://christorng.github.io/*
 // @exclude      https://github.com/*
+// @exclude      *://discord.com/*
+// @exclude      *://*.discord.com/*
+// @exclude      *://ebird.org/*
+// @exclude      *://*.ebird.org/*
+// @exclude      *://newsminimalist.com/*
+// @exclude      *://*.newsminimalist.com/*
+// @exclude      *://*ycombinator.com/*
+// @exclude      *://huggingface.co/*
+// @exclude      *://*.huggingface.co/*
+// @exclude      *://youtube.com/*
+// @exclude      *://*.youtube.com/*
+// @exclude      *://x.com/*
+// @exclude      *://*.x.com/*
+// @exclude      *://nitter.net/*
+// @exclude      *://*.nitter.net/*
+// @exclude      *://bing.com/*
+// @exclude      *://*.bing.com/*
+// @exclude      *://*.wikipedia.org/*
+// @exclude      *://reddit.com/*
+// @exclude      *://*.reddit.com/*
+// @exclude      *://arxiv.org/*
+// @exclude      *://*.arxiv.org/*
 // @grant        GM_info
 // @run-at       document-start
 // ==/UserScript==


### PR DESCRIPTION
### Motivation
- 需把使用者列出的多個主機/網域加入到三支 userscript 的排除規則中，避免這些站點觸發腳本行為。 
- 排除規則屬於 metadata 層級，應同步更新 `@version` 以反映變更時間。 
- 不需變更 `TestCases.md` 內容，但要確認自動化測試仍通過。 

### Description
- 在 `src/AllGoInternetArchive.user.js`、`src/ForceMobileView.user.js`、`src/ForceDarkMode.user.js` 的 metadata 區塊新增一組 `@exclude` 模式，涵蓋 `hackernews.betacat.io`、`theneurondaily.com`、`tam.gov.taipei`、`wiwi.*`、`*.kagi.com`、`chatgpt.com`、`christorng.github.io`、`github`、`discord.com`、`ebird.org`、`newsminimalist.com`、`*ycombinator.com`、`huggingface.co`、`youtube`、`x.com`、`nitter.net`、`bing.com`、`wikipedia`、`reddit`、`arxiv` 等所列項目與通配變體。 
- 只變更 metadata（新增 `@exclude` 與更新 `@version` 為 `2026-04-12_...` 格式），未修改腳本執行邏輯或其他程式碼。 
- 未變更 `TestCases.md` 的內容，僅以該檔做參考確認。 

### Testing
- 執行自動化測試 `node --test scripts/test-all-go-internet-archive.js scripts/test-force-mobile-view.js scripts/test-force-dark-mode.js`，所有測試皆通過（全部通過）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb906c7308322a31be7e7eb63dff4)