### PR TITLE
AutoOpenNewArticles：切回頁籤時自動重新整理列表頁

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Open external links in background tabs with a ↗︎ indicator on:
 
 ## [Auto Open New Articles User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/AutoOpenNewArticles.user.js)
 
-Track the latest seen article and auto-open newly listed items in background tabs with a yellow star on Taipei Astronomical Museum and The Neuron Daily.
+Track the latest seen article, auto-open newly listed items in background tabs with a yellow star, and reload listing pages when the tab becomes active on Taipei Astronomical Museum and The Neuron Daily.
 
 ## [Coding Diff Optimizer User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/CodingOptimizer.user.js)
 

--- a/scripts/test-auto-open-new-articles.js
+++ b/scripts/test-auto-open-new-articles.js
@@ -183,4 +183,24 @@ describe('AutoOpenNewArticles on The Neuron Daily listings', () => {
         assert.equal(newLink.firstChild.textContent, '★');
         assert.equal(hiddenMetaSpan.firstChild, null);
     });
+
+    test('reloads the listing page when the tab becomes active', () => {
+        const openCalls = [];
+        const { harness } = createAutoOpenHarness('https://www.theneurondaily.com/', {}, openCalls);
+        const main = harness.document.createElement('main');
+        harness.appendToBody(main);
+        main.appendChild(createLink(harness.document, 'https://www.theneurondaily.com/p/latest-ai-breakthrough'));
+
+        runAutoOpenScript(harness);
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+        assert.equal(harness.location.reloadCallCount, 0);
+
+        harness.document.visibilityState = 'hidden';
+        harness.dispatchDocumentEvent('visibilitychange');
+        assert.equal(harness.location.reloadCallCount, 0);
+
+        harness.document.visibilityState = 'visible';
+        harness.dispatchDocumentEvent('visibilitychange');
+        assert.equal(harness.location.reloadCallCount, 1);
+    });
 });

--- a/src/AutoOpenNewArticles.user.js
+++ b/src/AutoOpenNewArticles.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Auto Open New Articles
 // @namespace    http://tampermonkey.net/
-// @version      2026-03-18_1.1.1
-// @description  Track the latest seen article and open newly listed articles on Taipei Astronomical Museum and The Neuron Daily in background tabs with a yellow star.
+// @version      2026-05-20_1.2.0
+// @description  Track the latest seen article, open newly listed articles in background tabs with a yellow star, and reload listing pages when the tab becomes active on Taipei Astronomical Museum and The Neuron Daily.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
 // @downloadURL  https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/AutoOpenNewArticles.user.js
@@ -199,6 +199,25 @@
 
         GM_setValue(storageKey, latestId);
     }
+
+    function setupActiveTabReload() {
+        const siteConfig = getSiteConfig();
+        if (!siteConfig) {
+            return;
+        }
+
+        const reloadIfVisible = () => {
+            if (document.visibilityState && document.visibilityState !== 'visible') {
+                return;
+            }
+            window.location.reload();
+        };
+
+        document.addEventListener('visibilitychange', reloadIfVisible);
+        window.addEventListener('focus', reloadIfVisible);
+    }
+
+    setupActiveTabReload();
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', handleArticles);


### PR DESCRIPTION
### Motivation
- 使用者希望在切回目標網站的列表頁時自動重新整理以即時取得新文章摘要，且原本自動開新文章的行為需保留。 

### Description
- 更新 `src/AutoOpenNewArticles.user.js` 的 `@version` 為 `2026-05-20_1.2.0` 並擴充 `@description`。 
- 新增 `setupActiveTabReload()`，在支援的列表頁監聽 `visibilitychange` 與 `focus` 事件以在頁籤回到前景時呼叫 `window.location.reload()`。 
- 同步更新 `README.md` 中對 `Auto Open New Articles` 的說明以反映新行為。 
- 新增測試案例到 `scripts/test-auto-open-new-articles.js`，驗證從 `hidden` 轉為 `visible` 時會觸發重整。 

### Testing
- 執行 `node --test scripts/test-auto-open-new-articles.js`，相關測試案例皆通過。 
- 執行整個測試套件 `node --test`，所有自動化測試皆通過。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e394c49988322b49d7ff138a030cc)