### PR TITLE
feat: YouTubeTools 新增 1x/1.5x/2x 快速倍速按鈕

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Toggle the current page between original and Google Translate with Ctrl+Alt+S.
 
 ## [YouTube Tools User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/YouTubeTools.user.js)
 
-Show a top-right YouTube tools overlay with « » speed controls and the current playback rate on watch pages.
+Show a top-right YouTube tools overlay with « » speed controls, 1x/1.5x/2x quick buttons, and the current playback rate on watch pages.
 
 ## [Force Mobile View User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ForceMobileView.user.js)
 

--- a/scripts/test-youtube-tools.js
+++ b/scripts/test-youtube-tools.js
@@ -39,16 +39,26 @@ describe('YouTubeTools on captured watch pages', () => {
         const speedValue = overlay.querySelector('.tm-yt-speed-overlay__value');
 
         assert(overlay, 'Expected YouTube tools overlay.');
-        assert.equal(buttons.length, 2);
+        assert.equal(buttons.length, 5);
         assert.equal(speedValue.textContent, '1x');
 
         buttons[1].click();
         assert.equal(video.playbackRate, 1.25);
         assert.equal(speedValue.textContent, '1.25x');
 
-        video.playbackRate = 1.5;
-        video.dispatchEvent({ type: 'ratechange' });
+        const preset15 = [...buttons].find((button) => button.textContent === '1.5x');
+        const preset2 = [...buttons].find((button) => button.textContent === '2x');
+
+        assert(preset15, 'Expected a 1.5x preset button.');
+        assert(preset2, 'Expected a 2x preset button.');
+
+        preset15.click();
+        assert.equal(video.playbackRate, 1.5);
         assert.equal(speedValue.textContent, '1.5x');
+
+        preset2.click();
+        assert.equal(video.playbackRate, 2);
+        assert.equal(speedValue.textContent, '2x');
     });
 
     test('route change away from watch page removes the overlay', () => {

--- a/src/YouTubeTools.user.js
+++ b/src/YouTubeTools.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         YouTube Tools
 // @namespace    http://tampermonkey.net/
-// @version      2025-12-28_1.0.4
-// @description  Show a top-right YouTube tools overlay with « » speed controls and the current playback rate on watch pages.
+// @version      2026-05-20_1.0.5
+// @description  Show a top-right YouTube tools overlay with « » speed controls, 1x/1.5x/2x quick buttons, and the current playback rate on watch pages.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
 // @downloadURL  https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/YouTubeTools.user.js
@@ -65,6 +65,15 @@
     }
 
     function onRateChange() {
+        updateSpeedDisplay();
+    }
+
+    function setAbsoluteRate(rate) {
+        const video = currentVideo || document.querySelector('video');
+        if (!video) {
+            return;
+        }
+        video.playbackRate = clampRate(rate);
         updateSpeedDisplay();
     }
 
@@ -144,8 +153,8 @@
     position: fixed;
     top: 40px;
     right: 12px;
-    width: clamp(96px, 22vw, 120px);
-    height: 40px;
+    width: clamp(132px, 28vw, 170px);
+    min-height: 76px;
     z-index: 2147483647;
     color: rgba(255, 255, 255, 0.6);
     font-family: "Roboto", "Arial", sans-serif;
@@ -243,6 +252,35 @@
 #${overlayId} .tm-yt-speed-overlay__click--right:active {
     background: rgba(229, 9, 20, 0.38);
 }
+
+#${overlayId} .tm-yt-speed-overlay__presets {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 44px;
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+}
+
+#${overlayId} .tm-yt-speed-overlay__preset {
+    border: none;
+    border-radius: 999px;
+    padding: 4px 8px;
+    font-size: clamp(11px, 2.8vw, 13px);
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.88);
+    background: rgba(0, 0, 0, 0.48);
+    cursor: pointer;
+}
+
+#${overlayId} .tm-yt-speed-overlay__preset:hover {
+    background: rgba(255, 255, 255, 0.26);
+}
+
+#${overlayId} .tm-yt-speed-overlay__preset:active {
+    background: rgba(229, 9, 20, 0.46);
+}
 `;
         document.head.appendChild(style);
     }
@@ -288,9 +326,23 @@
         label.appendChild(speedValue);
         label.appendChild(rightIcon);
 
+        const presets = document.createElement('div');
+        presets.className = 'tm-yt-speed-overlay__presets';
+
+        [1, 1.5, 2].forEach((rate) => {
+            const preset = document.createElement('button');
+            preset.type = 'button';
+            preset.className = 'tm-yt-speed-overlay__preset';
+            preset.textContent = formatRate(rate);
+            preset.setAttribute('aria-label', `Set playback speed to ${formatRate(rate)}`);
+            preset.addEventListener('click', () => setAbsoluteRate(rate));
+            presets.appendChild(preset);
+        });
+
         overlay.appendChild(leftButton);
         overlay.appendChild(rightButton);
         overlay.appendChild(label);
+        overlay.appendChild(presets);
 
         const host = document.fullscreenElement || document.body;
         host.appendChild(overlay);


### PR DESCRIPTION
### Motivation
- 改善 YouTube 播放控制的易用性，提供常用倍速的一鍵切換選項以補強既有的 0.25x 微調按鈕。

### Description
- 在 `src/YouTubeTools.user.js` 中新增一組位於右上浮動控制列下方的快速倍速按鈕（`1x`、`1.5x`、`2x`）並加入 `setAbsoluteRate` 函式以直接設定倍速。 
- 調整 overlay 大小與樣式（CSS）以容納快速按鈕列，包含新增的 `.tm-yt-speed-overlay__presets` 與 `.tm-yt-speed-overlay__preset` 樣式規則。 
- 保留原有左右 `«` / `»` 按鈕的 0.25x 增減行為與即時倍速顯示，並在 userscript metadata 更新 `@version` 為 `2026-05-20_1.0.5` 與同步更新 `@description`。 
- 同步更新 `README.md` 內 `YouTube Tools` 條目簡述，並擴充 `scripts/test-youtube-tools.js` 測試以驗證新按鈕存在與功能。 

### Testing
- 執行 `node --test scripts/test-youtube-tools.js`，測試通過（相關子測試皆為 `ok`）。
- 執行整套測試 `node --test`，所有自動化測試皆通過（`pass 87 / fail 0` 當前輸出）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e39e44ec4832293ef74bdf20c7fbe)