### PR TITLE
AutoOpenNewArticles: add Wiwi.blog support and active-tab cache-busting reloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Open external links in background tabs with a ↗︎ indicator on:
 
 ## [Auto Open New Articles User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/AutoOpenNewArticles.user.js)
 
-Track the latest seen article and auto-open newly listed items in background tabs with a yellow star on Taipei Astronomical Museum and The Neuron Daily.
+Track the latest seen article, auto-open newly listed items in background tabs with a yellow star, and no-cache reload listing pages when the tab becomes active on Taipei Astronomical Museum, The Neuron Daily, and Wiwi Blog.
 
 ## [Coding Diff Optimizer User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/CodingOptimizer.user.js)
 

--- a/TestCases.md
+++ b/TestCases.md
@@ -62,6 +62,7 @@ Section note: automated tests inject the script and mock `GM_getValue`, `GM_setV
 - https://tam.gov.taipei/News_Link_pic.aspx?n=B64052C7930D4913 [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
 - https://www.theneurondaily.com/ [CONTENT_CLASS: INVALID_ANTI_BOT] [TEST_STATUS: AUTOMATED] (listing detection and new-item open flow validated with local DOM harness)
 - https://www.theneurondaily.com/archive [CONTENT_CLASS: INVALID_ANTI_BOT] [TEST_STATUS: AUTOMATED] (listing detection and new-item open flow validated with local DOM harness)
+- https://wiwi.blog/blog/ [CONTENT_CLASS: VALID_NON_ARTICLE_OR_LISTING] [TEST_STATUS: AUTOMATED] (listing detection, new-item open flow, and active-tab cache-busting reload validated with local DOM harness)
 
 # Coding Diff Optimizer
 - https://chatgpt.com/codex/tasks/task_e_68e41a320a388322a04ba2f35d096cd7 [CONTENT_CLASS: INVALID_ANTI_BOT] [TEST_STATUS: LIMITED] (anti-bot sample; synthetic diff selector on supported Codex URL)

--- a/scripts/test-auto-open-new-articles.js
+++ b/scripts/test-auto-open-new-articles.js
@@ -183,4 +183,77 @@ describe('AutoOpenNewArticles on The Neuron Daily listings', () => {
         assert.equal(newLink.firstChild.textContent, '★');
         assert.equal(hiddenMetaSpan.firstChild, null);
     });
+
+    test('reloads the listing page with cache-busting query when the tab becomes active', () => {
+        const openCalls = [];
+        const { harness } = createAutoOpenHarness('https://www.theneurondaily.com/', {}, openCalls);
+        const main = harness.document.createElement('main');
+        harness.appendToBody(main);
+        main.appendChild(createLink(harness.document, 'https://www.theneurondaily.com/p/latest-ai-breakthrough'));
+
+        runAutoOpenScript(harness);
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+        assert.equal(harness.location.reloadCallCount, 0);
+
+        harness.document.visibilityState = 'hidden';
+        harness.dispatchDocumentEvent('visibilitychange');
+        assert.equal(harness.location.replacedUrl, null);
+
+        harness.document.visibilityState = 'visible';
+        harness.dispatchDocumentEvent('visibilitychange');
+        assert(harness.location.replacedUrl);
+        const replacedUrl = new URL(harness.location.replacedUrl);
+        assert.equal(replacedUrl.origin, 'https://www.theneurondaily.com');
+        assert.equal(replacedUrl.pathname, '/');
+        assert.match(replacedUrl.search, /_tmr=\d+/);
+    });
+});
+
+describe('AutoOpenNewArticles on Wiwi Blog listing', () => {
+    test('stores the latest article and opens unseen Wiwi articles in background tabs', () => {
+        const storageKey = 'autoOpenNewArticles:lastSeen:wiwi:blog:listings';
+        const openCalls = [];
+        const { harness, gmStore } = createAutoOpenHarness(
+            'https://wiwi.blog/blog/',
+            { [storageKey]: 'wiwi:/blog/older-post' },
+            openCalls
+        );
+        const main = harness.document.createElement('main');
+        harness.appendToBody(main);
+
+        const latestLink = createLink(harness.document, 'https://wiwi.blog/blog/new-post', { textContent: 'New Post' });
+        const seenLink = createLink(harness.document, 'https://wiwi.blog/blog/older-post', { textContent: 'Older Post' });
+        const duplicateLatest = createLink(harness.document, 'https://wiwi.blog/blog/new-post', { textContent: 'Duplicate New Post' });
+        const nonArticle = createLink(harness.document, 'https://wiwi.blog/about', { textContent: 'About' });
+        main.append(latestLink, seenLink, duplicateLatest, nonArticle);
+
+        runAutoOpenScript(harness);
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        assert.equal(openCalls.length, 1);
+        assert.equal(openCalls[0].href, 'https://wiwi.blog/blog/new-post');
+        assert.equal(openCalls[0].options.active, false);
+        assert.equal(openCalls[0].options.insert, true);
+        assert.equal(gmStore.get(storageKey), 'wiwi:/blog/new-post');
+        assert.equal(latestLink.firstChild.textContent, '★');
+    });
+
+    test('reloads Wiwi listing with cache-busting query when tab becomes active', () => {
+        const openCalls = [];
+        const { harness } = createAutoOpenHarness('https://wiwi.blog/blog/', {}, openCalls);
+        const main = harness.document.createElement('main');
+        harness.appendToBody(main);
+        main.appendChild(createLink(harness.document, 'https://wiwi.blog/blog/new-post'));
+
+        runAutoOpenScript(harness);
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        harness.document.visibilityState = 'visible';
+        harness.dispatchDocumentEvent('visibilitychange');
+        assert(harness.location.replacedUrl);
+        const replacedUrl = new URL(harness.location.replacedUrl);
+        assert.equal(replacedUrl.origin, 'https://wiwi.blog');
+        assert.equal(replacedUrl.pathname, '/blog/');
+        assert.match(replacedUrl.search, /_tmr=\d+/);
+    });
 });

--- a/src/AutoOpenNewArticles.user.js
+++ b/src/AutoOpenNewArticles.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Auto Open New Articles
 // @namespace    http://tampermonkey.net/
-// @version      2026-03-18_1.1.1
-// @description  Track the latest seen article and open newly listed articles on Taipei Astronomical Museum and The Neuron Daily in background tabs with a yellow star.
+// @version      2026-05-27_1.3.0
+// @description  Track the latest seen article, open newly listed articles in background tabs with a yellow star, and no-cache reload listing pages when the tab becomes active on Taipei Astronomical Museum, The Neuron Daily, and Wiwi Blog.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
 // @downloadURL  https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/AutoOpenNewArticles.user.js
@@ -12,6 +12,7 @@
 // @match        https://tam.gov.taipei/News_Link_pic.aspx*
 // @match        https://www.theneurondaily.com/
 // @match        https://www.theneurondaily.com/archive*
+// @match        https://wiwi.blog/blog/
 // @grant        GM_getValue
 // @grant        GM_setValue
 // @grant        GM_openInTab
@@ -117,6 +118,50 @@
             };
         }
 
+        if (url.hostname === 'wiwi.blog') {
+            if (url.pathname !== '/blog/' && url.pathname !== '/blog') {
+                return null;
+            }
+
+            return {
+                scope: 'wiwi:blog:listings',
+                collectArticleLinks: () => {
+                    const candidates = Array.from(document.querySelectorAll('a[href]'));
+                    const seen = new Set();
+
+                    return candidates.filter((link) => {
+                        try {
+                            const articleUrl = new URL(link.href, window.location.href);
+                            const isArticle = articleUrl.origin === url.origin
+                                && articleUrl.pathname.startsWith('/blog/')
+                                && articleUrl.pathname !== '/blog/'
+                                && articleUrl.pathname !== '/blog';
+                            if (!isArticle) {
+                                return false;
+                            }
+
+                            const key = articleUrl.pathname;
+                            if (seen.has(key)) {
+                                return false;
+                            }
+                            seen.add(key);
+                            return true;
+                        } catch (error) {
+                            return false;
+                        }
+                    });
+                },
+                getArticleId: (link) => {
+                    try {
+                        const articleUrl = new URL(link.href, window.location.href);
+                        return `wiwi:${articleUrl.pathname}`;
+                    } catch (error) {
+                        return `wiwi:${link.href}`;
+                    }
+                }
+            };
+        }
+
         return null;
     }
 
@@ -199,6 +244,36 @@
 
         GM_setValue(storageKey, latestId);
     }
+
+    function setupActiveTabReload() {
+        const siteConfig = getSiteConfig();
+        if (!siteConfig) {
+            return;
+        }
+
+        let lastReloadAt = 0;
+
+        const reloadIfVisible = () => {
+            if (document.visibilityState && document.visibilityState !== 'visible') {
+                return;
+            }
+
+            const now = Date.now();
+            if (now - lastReloadAt < 1000) {
+                return;
+            }
+            lastReloadAt = now;
+
+            const nextUrl = new URL(window.location.href);
+            nextUrl.searchParams.set('_tmr', String(now));
+            window.location.replace(nextUrl.toString());
+        };
+
+        document.addEventListener('visibilitychange', reloadIfVisible);
+        window.addEventListener('focus', reloadIfVisible);
+    }
+
+    setupActiveTabReload();
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', handleArticles);


### PR DESCRIPTION
### Motivation
- Extend auto-open behavior to include `wiwi.blog` listings so unseen blog posts are opened in background tabs and marked in the UI.
- Prevent listing pages from serving stale content by reloading the listing with a cache-busting query when the tab becomes active.
- Bump the userscript version and update documentation and test cases to reflect the new site and behavior.

### Description
- Updated `src/AutoOpenNewArticles.user.js` with a version bump, expanded description, and a new `@match` for `https://wiwi.blog/blog/`.
- Added a site configuration for `wiwi.blog` that collects article links and generates stable article IDs for storage and deduplication.
- Implemented `setupActiveTabReload()` which listens for `visibilitychange` and `focus` and replaces the current URL with an `_tmr` timestamp query to force a no-cache reload.
- Added automated tests in `scripts/test-auto-open-new-articles.js` and updated `README.md` and `TestCases.md` to cover Wiwi support and the active-tab cache-busting reload behavior.

### Testing
- Ran the `scripts/test-auto-open-new-articles.js` automated test suite which includes new tests for Wiwi listing detection, new-article open flow, and visibility-triggered reloads.
- All automated tests related to `AutoOpenNewArticles` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e394c49988322b49d7ff138a030cc)