### PR TITLE
Bump AutoOpenNewArticles userscript version to 2026-06-09_1.3.1

### DIFF
--- a/src/AutoOpenNewArticles.user.js
+++ b/src/AutoOpenNewArticles.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Auto Open New Articles
 // @namespace    http://tampermonkey.net/
-// @version      2026-03-18_1.1.1
+// @version      2026-06-09_1.3.1
 // @description  Track the latest seen article and open newly listed articles on Taipei Astronomical Museum and The Neuron Daily in background tabs with a yellow star.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/


### PR DESCRIPTION
### Motivation
- Update the userscript metadata version to `2026-06-09_1.3.1` so releases and update checks reflect the latest release.

### Description
- Change the `// @version` header in `src/AutoOpenNewArticles.user.js` from `2026-03-18_1.1.1` to `2026-06-09_1.3.1`.

### Testing
- No automated tests were run for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e394c49988322b49d7ff138a030cc)