### PR TITLE
新增 HideBanner 對臺北市立天文館 News_Content 自動捲動標題支援

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Hide/click/scrollTo elements on specific sites for better reading experience:
 - [INSIDE](https://www.inside.com.tw/)
 - [Los Angeles Times](https://www.latimes.com/)
 - [What is Intelligence?](https://whatisintelligence.antikythera.org/)
+- [Taipei Astronomical Museum News Content](https://tam.gov.taipei/News_Content.aspx)
 
 ## [Fix Floating Elements User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/FixFloating.user.js)
 

--- a/TestCases.md
+++ b/TestCases.md
@@ -41,7 +41,9 @@
 - https://pansci.asia/archives/380040 [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
 - https://www.inside.com.tw/article/40278-is-taiwan-the-worlds-best-use-case-for-stablecoins [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
 - https://www.latimes.com/environment/story/2025-12-18/state-regulators-vote-to-keep-utility-profits-high-angering-customers [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
-- https://whatisintelligence.antikythera.org/chapter-02/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
+- https://whatisintelligence.antikythera.org/chapter-02/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
+- https://tam.gov.taipei/News_Content.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801&s=AB8D80ADF566657B [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
+- https://tam.gov.taipei/News_Content.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801&s=EA498826874ED925 [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED]
 
 # Fix Floating Elements
 - https://whatisintelligence.antikythera.org/chapter-02/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT]

--- a/scripts/test-hide-banner.js
+++ b/scripts/test-hide-banner.js
@@ -134,8 +134,12 @@ describe('HideBanner on captured pages', () => {
     });
 
 
-    test('tam.gov News_Content pages scroll to the article title', () => {
+    test('tam.gov single News_Content pages hide the fixed banner and scroll to the article title', () => {
         const harness = executeHideBanner('https://tam.gov.taipei/News_Content.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801&s=AB8D80ADF566657B');
+        const mobileBanner = harness.document.createElement('div');
+        mobileBanner.className = 'group base-mobile';
+        const logoBanner = harness.document.createElement('div');
+        logoBanner.className = 'simple-text major-logo';
         const content = harness.document.createElement('div');
         content.id = 'CCMS_Content';
         const wrapper = harness.document.createElement('div');
@@ -146,15 +150,54 @@ describe('HideBanner on captured pages', () => {
         title._rect = { top: 160, left: 0, right: 480, bottom: 200, width: 480, height: 40 };
         wrapper.appendChild(title);
         content.appendChild(wrapper);
+        harness.appendToBody(mobileBanner);
+        harness.appendToBody(logoBanner);
         harness.appendToBody(content);
 
         harness.dispatchDocumentEvent('DOMContentLoaded');
 
+        assert.equal(mobileBanner.style.display, 'none');
+        assert.equal(logoBanner.style.display, 'none');
         assert.equal(title.scrollIntoViewCallCount, 1);
+    });
+
+
+    test('tam.gov News_Content collection pages scroll to the first article link instead of the collection heading', () => {
+        const harness = executeHideBanner('https://tam.gov.taipei/News_Content.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801&s=EA498826874ED925');
+        const content = harness.document.createElement('div');
+        content.id = 'CCMS_Content';
+        const titleWrapper = harness.document.createElement('div');
+        titleWrapper.className = 'simple-text title';
+        const collectionTitle = harness.document.createElement('h3');
+        collectionTitle.textContent = '115-06-24天文新知彙整';
+        collectionTitle._rect = { top: 120, left: 0, right: 480, bottom: 160, width: 480, height: 40 };
+        titleWrapper.appendChild(collectionTitle);
+        const essay = harness.document.createElement('div');
+        essay.className = 'area-essay page-caption-p';
+        const orderedList = harness.document.createElement('ol');
+        const firstItem = harness.document.createElement('li');
+        const firstLink = harness.document.createElement('a');
+        firstLink.textContent = '遙遠的「暗影發射器」天體';
+        firstLink._rect = { top: 260, left: 0, right: 480, bottom: 320, width: 480, height: 60 };
+        firstItem.appendChild(firstLink);
+        orderedList.appendChild(firstItem);
+        essay.appendChild(orderedList);
+        content.appendChild(titleWrapper);
+        content.appendChild(essay);
+        harness.appendToBody(content);
+
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        assert.equal(firstLink.scrollIntoViewCallCount, 1);
+        assert.equal(collectionTitle.scrollIntoViewCallCount, 0);
     });
 
     test('tam.gov non-News_Content pages are not affected', () => {
         const harness = executeHideBanner('https://tam.gov.taipei/News_Photo.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801');
+        const mobileBanner = harness.document.createElement('div');
+        mobileBanner.className = 'group base-mobile';
+        const logoBanner = harness.document.createElement('div');
+        logoBanner.className = 'simple-text major-logo';
         const content = harness.document.createElement('div');
         content.id = 'CCMS_Content';
         const wrapper = harness.document.createElement('div');
@@ -163,10 +206,14 @@ describe('HideBanner on captured pages', () => {
         title._rect = { top: 160, left: 0, right: 480, bottom: 200, width: 480, height: 40 };
         wrapper.appendChild(title);
         content.appendChild(wrapper);
+        harness.appendToBody(mobileBanner);
+        harness.appendToBody(logoBanner);
         harness.appendToBody(content);
 
         harness.dispatchDocumentEvent('DOMContentLoaded');
 
+        assert.notEqual(mobileBanner.style.display, 'none');
+        assert.notEqual(logoBanner.style.display, 'none');
         assert.equal(title.scrollIntoViewCallCount, 0);
     });
 

--- a/scripts/test-hide-banner.js
+++ b/scripts/test-hide-banner.js
@@ -134,7 +134,7 @@ describe('HideBanner on captured pages', () => {
     });
 
 
-    test('tam.gov single News_Content pages hide the fixed banner and scroll to the article title', () => {
+    test('tam.gov single News_Content pages hide fixed banners, hide AI summaries, and scroll to the article title', () => {
         const harness = executeHideBanner('https://tam.gov.taipei/News_Content.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801&s=AB8D80ADF566657B');
         const mobileBanner = harness.document.createElement('div');
         mobileBanner.className = 'group base-mobile';
@@ -142,6 +142,8 @@ describe('HideBanner on captured pages', () => {
         logoBanner.className = 'simple-text major-logo';
         const content = harness.document.createElement('div');
         content.id = 'CCMS_Content';
+        const aiSummary = harness.document.createElement('div');
+        aiSummary.className = 'area-customize ai-wrapper';
         const wrapper = harness.document.createElement('div');
         wrapper.className = 'simple-text title';
         const title = harness.document.createElement('h3');
@@ -150,6 +152,7 @@ describe('HideBanner on captured pages', () => {
         title._rect = { top: 160, left: 0, right: 480, bottom: 200, width: 480, height: 40 };
         wrapper.appendChild(title);
         content.appendChild(wrapper);
+        content.appendChild(aiSummary);
         harness.appendToBody(mobileBanner);
         harness.appendToBody(logoBanner);
         harness.appendToBody(content);
@@ -158,11 +161,12 @@ describe('HideBanner on captured pages', () => {
 
         assert.equal(mobileBanner.style.display, 'none');
         assert.equal(logoBanner.style.display, 'none');
+        assert.equal(aiSummary.style.display, 'none');
         assert.equal(title.scrollIntoViewCallCount, 1);
     });
 
 
-    test('tam.gov News_Content collection pages scroll to the first article link instead of the collection heading', () => {
+    test('tam.gov News_Content collection pages scroll to the first article heading instead of the collection list', () => {
         const harness = executeHideBanner('https://tam.gov.taipei/News_Content.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801&s=EA498826874ED925');
         const content = harness.document.createElement('div');
         content.id = 'CCMS_Content';
@@ -179,16 +183,24 @@ describe('HideBanner on captured pages', () => {
         const firstLink = harness.document.createElement('a');
         firstLink.textContent = '遙遠的「暗影發射器」天體';
         firstLink._rect = { top: 260, left: 0, right: 480, bottom: 320, width: 480, height: 60 };
+        const firstHeadingParagraph = harness.document.createElement('p');
+        const firstHeading = harness.document.createElement('strong');
+        firstHeading.id = 'A';
+        firstHeading.textContent = '遙遠的「暗影發射器」天體';
+        firstHeading._rect = { top: 640, left: 0, right: 480, bottom: 700, width: 480, height: 60 };
+        firstHeadingParagraph.appendChild(firstHeading);
         firstItem.appendChild(firstLink);
         orderedList.appendChild(firstItem);
         essay.appendChild(orderedList);
+        essay.appendChild(firstHeadingParagraph);
         content.appendChild(titleWrapper);
         content.appendChild(essay);
         harness.appendToBody(content);
 
         harness.dispatchDocumentEvent('DOMContentLoaded');
 
-        assert.equal(firstLink.scrollIntoViewCallCount, 1);
+        assert.equal(firstHeading.scrollIntoViewCallCount, 1);
+        assert.equal(firstLink.scrollIntoViewCallCount, 0);
         assert.equal(collectionTitle.scrollIntoViewCallCount, 0);
     });
 

--- a/scripts/test-hide-banner.js
+++ b/scripts/test-hide-banner.js
@@ -133,6 +133,43 @@ describe('HideBanner on captured pages', () => {
         assert.equal(headline.scrollIntoViewCallCount, 1);
     });
 
+
+    test('tam.gov News_Content pages scroll to the article title', () => {
+        const harness = executeHideBanner('https://tam.gov.taipei/News_Content.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801&s=AB8D80ADF566657B');
+        const content = harness.document.createElement('div');
+        content.id = 'CCMS_Content';
+        const wrapper = harness.document.createElement('div');
+        wrapper.className = 'simple-text title';
+        const title = harness.document.createElement('h3');
+        title.className = 'h3';
+        title.textContent = '捕獲關鍵第三例！「無暗物質星系鏈」也許能解開一項史詩級謎團';
+        title._rect = { top: 160, left: 0, right: 480, bottom: 200, width: 480, height: 40 };
+        wrapper.appendChild(title);
+        content.appendChild(wrapper);
+        harness.appendToBody(content);
+
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        assert.equal(title.scrollIntoViewCallCount, 1);
+    });
+
+    test('tam.gov non-News_Content pages are not affected', () => {
+        const harness = executeHideBanner('https://tam.gov.taipei/News_Photo.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801');
+        const content = harness.document.createElement('div');
+        content.id = 'CCMS_Content';
+        const wrapper = harness.document.createElement('div');
+        wrapper.className = 'simple-text title';
+        const title = harness.document.createElement('h3');
+        title._rect = { top: 160, left: 0, right: 480, bottom: 200, width: 480, height: 40 };
+        wrapper.appendChild(title);
+        content.appendChild(wrapper);
+        harness.appendToBody(content);
+
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        assert.equal(title.scrollIntoViewCallCount, 0);
+    });
+
     test('antikythera hides menu chrome including shadow content', () => {
         const harness = executeHideBanner('https://whatisintelligence.antikythera.org/chapter-02/');
         const menuHost = harness.document.createElement('antikythera-menu');

--- a/src/HideBanner.user.js
+++ b/src/HideBanner.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hide Banner script
 // @namespace    http://tampermonkey.net/
-// @version      2026-06-25_1.5.4
+// @version      2026-06-25_1.5.5
 // @description  Hide/click/scroll to specified elements on multiple websites
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -72,11 +72,12 @@
             path: '/News_Content.aspx',
             hide: [
                 '.group.base-mobile',
-                '.simple-text.major-logo'
+                '.simple-text.major-logo',
+                '#CCMS_Content .area-customize.ai-wrapper'
             ],
             click: [],
             scrollTo: [
-                '#CCMS_Content .area-essay.page-caption-p ol a',
+                '#CCMS_Content .area-essay.page-caption-p strong[id]',
                 '#CCMS_Content .simple-text.title h3'
             ]
         }

--- a/src/HideBanner.user.js
+++ b/src/HideBanner.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hide Banner script
 // @namespace    http://tampermonkey.net/
-// @version      2026-06-24_1.5.3
+// @version      2026-06-25_1.5.4
 // @description  Hide/click/scroll to specified elements on multiple websites
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -70,9 +70,15 @@
         },
         'tam.gov.taipei': {
             path: '/News_Content.aspx',
-            hide: [],
+            hide: [
+                '.group.base-mobile',
+                '.simple-text.major-logo'
+            ],
             click: [],
-            scrollTo: '#CCMS_Content .simple-text.title h3'
+            scrollTo: [
+                '#CCMS_Content .area-essay.page-caption-p ol a',
+                '#CCMS_Content .simple-text.title h3'
+            ]
         }
     };
 
@@ -132,7 +138,8 @@
     function scrollToElement() {
         if (!currentConfig.scrollTo) return;
 
-        const element = queryAll(currentConfig.scrollTo)[0];
+        const selectors = Array.isArray(currentConfig.scrollTo) ? currentConfig.scrollTo : [currentConfig.scrollTo];
+        const element = selectors.flatMap(selector => Array.from(queryAll(selector)))[0];
         if (!element) return;
 
         const elementRect = element.getBoundingClientRect();

--- a/src/HideBanner.user.js
+++ b/src/HideBanner.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hide Banner script
 // @namespace    http://tampermonkey.net/
-// @version      2026-01-17_1.5.2
+// @version      2026-06-24_1.5.3
 // @description  Hide/click/scroll to specified elements on multiple websites
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -13,6 +13,7 @@
 // @match        https://www.inside.com.tw/*
 // @match        https://www.latimes.com/*
 // @match        https://whatisintelligence.antikythera.org/*
+// @match        https://tam.gov.taipei/News_Content.aspx*
 // @grant        none
 // ==/UserScript==
 
@@ -66,11 +67,26 @@
             ],
             click: [],
             scrollTo: null
+        },
+        'tam.gov.taipei': {
+            path: '/News_Content.aspx',
+            hide: [],
+            click: [],
+            scrollTo: '#CCMS_Content .simple-text.title h3'
         }
     };
 
-    // Get selectors for current domain
-    const currentConfig = domainSelectors[window.location.hostname] || { hide: [], click: [], scrollTo: null };
+    function getCurrentConfig() {
+        const config = domainSelectors[window.location.hostname];
+        if (!config) return { hide: [], click: [], scrollTo: null };
+        if (config.path && window.location.pathname !== config.path) {
+            return { hide: [], click: [], scrollTo: null };
+        }
+        return config;
+    }
+
+    // Get selectors for current domain and supported path
+    const currentConfig = getCurrentConfig();
 
     // Track clicked elements to avoid repeated clicks
     const clickedElements = new WeakSet();


### PR DESCRIPTION
### Motivation
- 因應臺北市立天文館的文章頁面結構，讓 `HideBanner` 在 `News_Content.aspx` 類型的文章頁自動捲動到內文標題以改善閱讀體驗。

### Description
- 在 `src/HideBanner.user.js` 中增加 `@match https://tam.gov.taipei/News_Content.aspx*` 並將腳本版本更新為 `2026-06-24_1.5.3`。 
- 新增 `tam.gov.taipei` 的 domain 配置，加入 `path: '/News_Content.aspx'` 的路徑檢查，並設定 `scrollTo: '#CCMS_Content .simple-text.title h3'` 作為捲動目標。 
- 把原本的 domain 解析改為 `getCurrentConfig()`，若 `path` 不符則不啟用該站的行為以避免影響其它頁面（例如 `News_Photo.aspx`）。
- 更新 `scripts/test-hide-banner.js`、`README.md` 與 `TestCases.md`，新增針對 `News_Content.aspx` 的自動化測試範例與文件條目。 

### Testing
- 執行 `node --test scripts/test-hide-banner.js`，新增的 Taipei museum 相關測試與既有 HideBanner 測試皆通過（全部子測試通過）。
- 執行整套 `node --test` 時 HideBanner 相關測試通過，但整體測試套件中存在與本次修改無關的 `ForceMobileView` 兩個子測試失敗（與本 PR 變更無關）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb58de2ec8322b97a4bb1f3cb1829)