### PR TITLE
為 Paul Bourke 網站預設啟用 Force Mobile View

### DIFF
--- a/TestCases.md
+++ b/TestCases.md
@@ -85,6 +85,7 @@ Section note: automated tests inject the script and mock `GM_info`.
 - https://lcamtuf.coredump.cx/prep/index-old.shtml [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (non-matched URL remains off by default even with tiny fonts)
 - https://daringfireball.net/2026/03/your_frustration_is_the_product [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: LIMITED] (mobile spacing logic is AUTOMATED via synthetic DOM harness, including minimal side-whitespace enforcement; full live-page capture coverage is still limited)
 - https://steveblank.com/2026/04/09/nowhere-is-safe/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (line-height overlap regression is simulated with local DOM harness against captured page content)
+- https://paulbourke.net/geometry/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (URL match auto-enable behavior is validated with a local DOM harness)
 
 # Better Mobile View
 - https://hackernews.betacat.io/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT]

--- a/scripts/test-force-mobile-view.js
+++ b/scripts/test-force-mobile-view.js
@@ -24,7 +24,7 @@ function executeForceMobileView(url, options = {}) {
         readyState: 'loading',
         gmInfo: {
             script: {
-                matches: ['https://news.ycombinator.com/item?*', 'https://archive.is/*', '*://*/*']
+                matches: ['https://news.ycombinator.com/item?*', 'https://archive.is/*', 'https://paulbourke.net/*', 'https://www.paulbourke.net/*', '*://*/*']
             }
         },
         matchMedia(query) {
@@ -65,6 +65,8 @@ function executeForceMobileView(url, options = {}) {
         harness.document.body.innerHTML = options.fixtureHtml;
     }
 
+    const setupResult = typeof options.setupBody === 'function' ? options.setupBody(harness) : {};
+
     const textElement = harness.document.createElement('span');
     textElement.textContent = 'small text';
     harness.appendToBody(textElement);
@@ -72,7 +74,7 @@ function executeForceMobileView(url, options = {}) {
     harness.context.globalThis = harness.context;
     harness.context.global = harness.context;
     vm.runInNewContext(scriptContents, harness.context, { filename: scriptPath });
-    return { harness, textElement };
+    return { harness, textElement, ...setupResult };
 }
 
 describe('ForceMobileView on captured pages', () => {
@@ -103,6 +105,18 @@ describe('ForceMobileView on captured pages', () => {
         assert.equal(textElement.getAttribute('data-tm-force-width-min-font'), 'true');
     });
 
+
+    test('paulbourke.net pages auto-enable mobile view by default', () => {
+        const { harness } = executeForceMobileView('https://paulbourke.net/geometry/');
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        const style = harness.document.getElementById('tm-force-width-style');
+        const button = harness.document.body.children.find((child) => child.tagName === 'BUTTON' && child.textContent === '↔');
+
+        assert(style, 'Expected Paul Bourke pages to auto-enable mobile view style.');
+        assert(button, 'Expected mobile view toggle button to be created.');
+        assert.equal(button.getAttribute('aria-pressed'), 'true');
+    });
 
     test('non-matched URLs no longer auto-enable mobile view even on tiny-font pages', () => {
         const { harness } = executeForceMobileView('https://lcamtuf.coredump.cx/prep/index-old.shtml', {
@@ -144,7 +158,14 @@ describe('ForceMobileView on captured pages', () => {
     });
 
     test('excessive horizontal spacing is trimmed on enable and restored on disable', () => {
-        const { harness } = executeForceMobileView('https://archive.is/75aY9', {
+        const { harness, post } = executeForceMobileView('https://archive.is/75aY9', {
+            setupBody(harness) {
+                const post = harness.document.createElement('article');
+                post.id = 'post';
+                post.textContent = 'content';
+                harness.appendToBody(post);
+                return { post };
+            },
             computedStyle(element) {
                 return {
                     fontSize: '16px',
@@ -155,10 +176,6 @@ describe('ForceMobileView on captured pages', () => {
                 };
             }
         });
-        const post = harness.document.createElement('article');
-        post.id = 'post';
-        post.textContent = 'content';
-        harness.appendToBody(post);
         harness.dispatchDocumentEvent('DOMContentLoaded');
 
         const button = harness.document.body.children.find((child) => child.tagName === 'BUTTON' && child.textContent === '↔');
@@ -222,6 +239,7 @@ describe('ForceMobileView on captured pages', () => {
         span.textContent = 'Dense translated text';
         paragraph.appendChild(span);
         harness.appendToBody(paragraph);
+        harness.triggerMutation([paragraph]);
 
         const legacyLineHeight = 12;
         const legacyFontAfterBoost = 18;

--- a/src/ForceMobileView.user.js
+++ b/src/ForceMobileView.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Force Mobile View
 // @namespace    http://tampermonkey.net/
-// @version      2026-05-20_1.7.5
+// @version      2026-07-10_1.7.6
 // @description  Keep pages within the viewport width, trim excessive horizontal spacing on all enabled pages, wrap long content, and expose a draggable top-right ↔ toggle button with auto-enable for matched URLs.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
@@ -10,6 +10,8 @@
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=www.tampermonkey.net
 // @match        https://news.ycombinator.com/item?*
 // @match        https://archive.is/*
+// @match        https://paulbourke.net/*
+// @match        https://www.paulbourke.net/*
 // @match        *://*/*
 // @exclude      *://hackernews.betacat.io/*
 // @exclude      *://*.hackernews.betacat.io/*


### PR DESCRIPTION
### Motivation
- 讓 `Force Mobile View` 在 paulbourke.net 底下的所有頁面預設啟用，以改善該站在窄螢幕/行動檢視下的閱讀體驗。
- 同時更新使用者腳本的 metadata `@version`，以符合腳本變更的版本規範。

### Description
- 在 `src/ForceMobileView.user.js` 中將 `@version` 更新為 `2026-07-10_1.7.6` 並新增 `// @match https://paulbourke.net/*` 與 `// @match https://www.paulbourke.net/*` 以讓腳本自動啟用 paulbourke 網站頁面。
- 在 `scripts/test-force-mobile-view.js` 中擴充 mock `GM_info` 的 `matches` 清單以包含 `paulbourke.net`，並新增自動化測試 `paulbourke.net pages auto-enable mobile view by default` 驗證自動啟用行為；同時加入 `setupBody` / mutation trigger 的測試協助函式以確保動態加入元素時也會被觀察器處理。
- 在 `TestCases.md` 新增 `https://paulbourke.net/geometry/` 條目並標註為 `[TEST_STATUS: AUTOMATED]`，說明已使用本地 DOM harness 驗證 URL match 的自動啟用行為。

### Testing
- 執行 `node --test` 完整測試套件，所有測試通過（`# pass 94`，`# fail 0`）。
- 已單獨執行 `node --test scripts/test-force-mobile-view.js` 確認新增的 paulbourke 測試與現有測試皆通過。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a504f93b5c8832285dc8a65191de360)