### PR TITLE
Support paulbourke.net in ArticlesExternalNewTab and add tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ Turn floating toolbars and sticky overlays into scrollable elements on:
 
 ## [Articles External New Tab User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ArticlesExternalNewTab.user.js)
 
-Open external links in background tabs with a ↗︎ indicator on:
+Open supported article links in background tabs with a ↗︎ indicator on:
 
 - [Hacker News](https://news.ycombinator.com/)
 - [Hacker News Summary](https://hackernews.betacat.io/)
 - [The Neuron Daily](https://www.theneurondaily.com/)
 - [Taipei Astronomical Museum News](https://tam.gov.taipei/)
 - [Wiwi Blog](https://wiwi.blog/blog/)
+- [Paul Bourke](https://paulbourke.net/)
 
 ## [Auto Open New Articles User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/AutoOpenNewArticles.user.js)
 

--- a/TestCases.md
+++ b/TestCases.md
@@ -57,6 +57,7 @@ Section note: automated tests inject the script and mock `GM_openInTab`.
 - https://tam.gov.taipei/News_Photo.aspx?n=EF86D8AF23B9A85B&sms=F32C4FF0AC5C2801 [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
 - https://tam.gov.taipei/News_Link_pic.aspx?n=B64052C7930D4913&sms=2CF1F5E2E0B96411 [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
 - https://wiwi.blog/blog/ [CONTENT_CLASS: VALID_NON_ARTICLE_OR_LISTING] [TEST_STATUS: AUTOMATED]
+- https://paulbourke.net/ [CONTENT_CLASS: VALID_ARTICLE_CONTENT] [TEST_STATUS: AUTOMATED] (all-link behavior is validated with a local DOM harness)
 
 # AutoOpenNewArticles
 Section note: automated tests inject the script and mock `GM_getValue`, `GM_setValue`, and `GM_openInTab`.

--- a/scripts/test-articles-external-new-tab.js
+++ b/scripts/test-articles-external-new-tab.js
@@ -176,6 +176,44 @@ describe('ArticlesExternalNewTab on captured listings', () => {
         assert.equal(openCalls[0].options.insert, true);
     });
 
+    test('Paul Bourke pages open every link in background tabs', () => {
+        const openCalls = [];
+        const harness = createArticlesHarness('https://paulbourke.net/geometry/', openCalls);
+        const externalLink = createLink(harness.document, 'https://example.com/reference', { textContent: 'external' });
+        const internalLink = createLink(harness.document, 'https://paulbourke.net/geometry/polygonise/', { textContent: 'internal' });
+        const wwwInternalLink = createLink(harness.document, 'https://www.paulbourke.net/geometry/', { textContent: 'www internal' });
+        harness.appendToBody(externalLink);
+        harness.appendToBody(internalLink);
+        harness.appendToBody(wwwInternalLink);
+        runArticlesScript(harness);
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+
+        assert.equal(externalLink.target, '_blank');
+        assert.equal(internalLink.target, '_blank');
+        assert.equal(wwwInternalLink.target, '_blank');
+
+        const clickEvent = createMouseEvent('click');
+        externalLink.dispatchEvent(clickEvent);
+        assert.equal(clickEvent.defaultPrevented, true);
+        assert.equal(openCalls[0].href, 'https://example.com/reference');
+        assert.equal(openCalls[0].options.active, false);
+        assert.equal(openCalls[0].options.insert, true);
+
+        const internalClickEvent = createMouseEvent('click');
+        internalLink.dispatchEvent(internalClickEvent);
+        assert.equal(internalClickEvent.defaultPrevented, true);
+        assert.equal(openCalls[1].href, 'https://paulbourke.net/geometry/polygonise/');
+        assert.equal(openCalls[1].options.active, false);
+        assert.equal(openCalls[1].options.insert, true);
+
+        const wwwInternalClickEvent = createMouseEvent('click');
+        wwwInternalLink.dispatchEvent(wwwInternalClickEvent);
+        assert.equal(wwwInternalClickEvent.defaultPrevented, true);
+        assert.equal(openCalls[2].href, 'https://www.paulbourke.net/geometry/');
+        assert.equal(openCalls[2].options.active, false);
+        assert.equal(openCalls[2].options.insert, true);
+    });
+
     test('The Neuron Daily article sanitizes tracking parameters for external links', () => {
         const html = loadFixture('www.theneurondaily.com_p_you-can-now-build-agents-and-apps-inside-chatgpt.html');
         assert.match(html, /CONTENT_CLASS:\s*INVALID_ANTI_BOT/);

--- a/src/ArticlesExternalNewTab.user.js
+++ b/src/ArticlesExternalNewTab.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Articles External Links New Tab
 // @namespace    http://tampermonkey.net/
-// @version      2026-03-17_2.1.3
-// @description  Open external links in background tabs with a ↗︎ indicator on Hacker News, Hacker News Summary, The Neuron Daily, Taipei Astronomical Museum News, and Wiwi Blog.
+// @version      2026-07-10_2.1.5
+// @description  Open supported article links in background tabs with a ↗︎ indicator on Hacker News, Hacker News Summary, The Neuron Daily, Taipei Astronomical Museum News, Wiwi Blog, and Paul Bourke.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
 // @downloadURL  https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ArticlesExternalNewTab.user.js
@@ -14,6 +14,8 @@
 // @match        https://tam.gov.taipei/News_Photo.aspx*
 // @match        https://tam.gov.taipei/News_Link_pic.aspx*
 // @match        https://wiwi.blog/blog/*
+// @match        https://paulbourke.net/*
+// @match        https://www.paulbourke.net/*
 // @grant        GM_openInTab
 // ==/UserScript==
 
@@ -132,6 +134,10 @@
             if (isBlogPage) {
                 return url.hostname !== 'wiwi.blog';
             }
+        }
+
+        if (pageHost === 'paulbourke.net' || pageHost === 'www.paulbourke.net') {
+            return true;
         }
 
         return false;


### PR DESCRIPTION
### Motivation
- Add support for treating all links on Paul Bourke pages as "open in background tab" to improve navigation consistency for that site.
- Update documentation and testcases to reflect the newly supported host.

### Description
- Updated `src/ArticlesExternalNewTab.user.js` to bump the version and extend the user script description to include Paul Bourke. 
- Added `@match` patterns for `https://paulbourke.net/*` and `https://www.paulbourke.net/*` and updated the URL support check to return `true` for those hosts. 
- Added a new automated test in `scripts/test-articles-external-new-tab.js` that verifies every link on Paul Bourke pages opens in background tabs and appended the site to `README.md` and `TestCases.md`.

### Testing
- Ran the `ArticlesExternalNewTab` automated test suite which includes the new `Paul Bourke pages open every link in background tabs` test. 
- All automated tests in the modified suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a505ddae21083228976400201c52629)