### PR TITLE
全螢幕時隱藏 YouTube 播放速度面板（hover 顯示）

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Toggle the current page between original and Google Translate with Ctrl+Alt+S.
 
 ## [YouTube Tools User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/YouTubeTools.user.js)
 
-Show a top-right YouTube tools overlay with « » speed controls, 1x/1.5x/2x quick buttons, and the current playback rate on watch pages.
+Show a top-right YouTube playback-speed overlay that hides in fullscreen until hovered.
 
 ## [Force Mobile View User Script](https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/ForceMobileView.user.js)
 

--- a/TestCases.md
+++ b/TestCases.md
@@ -77,7 +77,7 @@ Section note: automated tests inject the script and mock `GM_getValue`, `GM_setV
 - https://indieweb.org/POSSE [CONTENT_CLASS: VALID_ARTICLE_CONTENT]
 
 # YouTube Tools
-- https://www.youtube.com/watch?v=nCg3aXn5F3M [CONTENT_CLASS: VALID_NON_ARTICLE_OR_LISTING]
+- https://www.youtube.com/watch?v=nCg3aXn5F3M [CONTENT_CLASS: VALID_NON_ARTICLE_OR_LISTING] [TEST_STATUS: AUTOMATED] (playback controls and fullscreen hover visibility validated with a local DOM harness)
 
 # Force Mobile View
 Section note: automated tests inject the script and mock `GM_info`.

--- a/scripts/test-youtube-tools.js
+++ b/scripts/test-youtube-tools.js
@@ -61,6 +61,32 @@ describe('YouTubeTools on captured watch pages', () => {
         assert.equal(speedValue.textContent, '2x');
     });
 
+    test('fullscreen hides the overlay until its top-right hover area is entered', () => {
+        const { harness, video } = executeYouTubeTools('https://www.youtube.com/watch?v=nCg3aXn5F3M');
+        harness.dispatchDocumentEvent('DOMContentLoaded');
+        harness.flushAnimationFrames();
+
+        const overlay = harness.document.getElementById('tm-yt-speed-overlay');
+        const style = harness.document.getElementById('tm-yt-speed-overlay-style');
+
+        assert(overlay, 'Expected YouTube tools overlay.');
+        assert.equal(overlay.classList.contains('tm-yt-speed-overlay--fullscreen'), false);
+        assert.match(style.textContent, /tm-yt-speed-overlay--fullscreen \{\s*position: absolute;\s*opacity: 0;/);
+        assert.match(style.textContent, /tm-yt-speed-overlay--fullscreen:hover \{\s*opacity: 1;/);
+
+        harness.document.fullscreenElement = video;
+        harness.dispatchWindowEvent('fullscreenchange');
+
+        assert.equal(overlay.classList.contains('tm-yt-speed-overlay--fullscreen'), true);
+        assert.equal(overlay.parentElement, video);
+
+        harness.document.fullscreenElement = null;
+        harness.dispatchWindowEvent('fullscreenchange');
+
+        assert.equal(overlay.classList.contains('tm-yt-speed-overlay--fullscreen'), false);
+        assert.equal(overlay.parentElement, harness.document.body);
+    });
+
     test('route change away from watch page removes the overlay', () => {
         const { harness } = executeYouTubeTools('https://www.youtube.com/watch?v=nCg3aXn5F3M');
         harness.dispatchDocumentEvent('DOMContentLoaded');

--- a/src/YouTubeTools.user.js
+++ b/src/YouTubeTools.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         YouTube Tools
 // @namespace    http://tampermonkey.net/
-// @version      2026-05-20_1.0.5
-// @description  Show a top-right YouTube tools overlay with « » speed controls, 1x/1.5x/2x quick buttons, and the current playback rate on watch pages.
+// @version      2026-07-23_1.0.6
+// @description  Show a top-right YouTube playback-speed overlay that hides in fullscreen until hovered.
 // @author       ChrisTorng
 // @homepage     https://github.com/ChrisTorng/TampermonkeyScripts/
 // @downloadURL  https://github.com/ChrisTorng/TampermonkeyScripts/raw/main/src/YouTubeTools.user.js
@@ -160,11 +160,17 @@
     font-family: "Roboto", "Arial", sans-serif;
     pointer-events: auto;
     user-select: none;
-    transition: color 160ms ease;
+    opacity: 1;
+    transition: color 160ms ease, opacity 0s;
 }
 
 #${overlayId}.tm-yt-speed-overlay--fullscreen {
     position: absolute;
+    opacity: 0;
+}
+
+#${overlayId}.tm-yt-speed-overlay--fullscreen:hover {
+    opacity: 1;
 }
 
 #${overlayId} .tm-yt-speed-overlay__click {


### PR DESCRIPTION
### Motivation
- 讓 YouTube 右上角的播放速度面板在非全螢幕時持續顯示，而在進入全螢幕時立即隱藏並僅在滑鼠移入該區域時暫時顯示以避免覆蓋畫面。
- 透過測試與文件同步，確保行為在本地 DOM harness 的自動化測試中可回歸驗證。 

### Description
- 更新 userscript metadata 的 `@version` 為 `2026-07-23_1.0.6` 並修改 `@description` 為說明全螢幕隱藏與 hover 顯示行為。 
- 在 `src/YouTubeTools.user.js` 中新增與修改 CSS，將全螢幕樣式 `tm-yt-speed-overlay--fullscreen` 設為 `opacity: 0` 並以 `:hover` 使其暫時 `opacity: 1`，同時調整 overlay 的 `transition` 設定以支援即時隱藏。 
- 將 README 的簡短說明同步為新的行為描述並把 TestCases.md 中的 YouTube 條目標記為自動化覆蓋且補上說明。 
- 新增/修改 `scripts/test-youtube-tools.js` 回歸測試以模擬 `fullscreenchange` 並驗證面板在全螢幕下被隱藏、附加到 `fullscreenElement`、以及恢復到文件主體後回到可見狀態。 

### Testing
- 執行 `node --test`，整套測試成功通過（96 個測試通過，0 失敗）。
- 執行 `npm run generate:index`，成功產生 `index.html` / `TestCases.html` 並更新 README/TestCases 的變更。 
- 執行 `git diff --check`，無發現格式/whitespace 問題，檢查通過。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6213a5b0c0832280aae7cd878084db)